### PR TITLE
Facet filter improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.6.0
+* `facet` options are sorted by count
 * `facet` options filter now translates words to intersection regexes
 * `facet` properly filters _before_ limiting (so filter works properly)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.0
+* `facet` options filter now translates words to intersection regexes
+* `facet` properly filters _before_ limiting (so filter works properly)
+
 # 0.5.0
 * Add `dateType ` support to date type (with `date`, `timestamp`, and `unix ` options)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -74,18 +74,18 @@ describe('facet', () => {
       let limitIndex = _.findIndex('$limit', queries[0])
       expect(limitIndex > filterIndex).to.be.true
     })
-    it('should support optionsFilter with multiple words', async () => {
+    it('should support optionsFilter with multiple words and spaces', async () => {
       queries = []
       let context = {
-        field: 'myField',
-        optionsFilter: 'cable usb',
+        field: 'categoriesInfo',
+        optionsFilter: '  dis  comp    ',
       }
       await facet.result(context, search)
       let filterAgg = _.find('$match', queries[0])
       expect(filterAgg).to.deep.equal({
         $match: {
           _id: {
-            $regex: '.*(?=.*cable.*)(?=.*usb.*).*',
+            $regex: '.*(?=.*dis.*)(?=.*comp.*).*',
             $options: 'i',
           },
         },


### PR DESCRIPTION
Fixes #31

* `facet` options are sorted by count
* `facet` options filter now translates words to intersection regexes
* `facet` properly filters _before_ limiting (so filter works properly)