### PR TITLE
`number` properly supports casting strings to numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.2
+* `number` properly supports casting strings to numbers
+
 # 0.6.1
 * Fix bug in `statistical` when there are no results
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/number.js
+++ b/src/example-types/number.js
@@ -6,11 +6,15 @@ let cleanFilter = _.flow(
 )
 
 module.exports = {
-  hasValue: context => _.isNumber(context.min) || _.isNumber(context.max),
-  filter: context => ({
-    [context.field]: cleanFilter({
-      $gte: context.min,
-      $lte: context.max,
+  hasValue: _.flow(
+    _.pick(['min', 'max']),
+    _.mapValues(_.toNumber),
+    _.some(x => !_.isNaN(x))
+  ),
+  filter: ({field, min, max}) => ({
+    [field]: cleanFilter({
+      $gte: min,
+      $lte: max,
     }),
   }),
 }

--- a/src/example-types/number.js
+++ b/src/example-types/number.js
@@ -11,7 +11,7 @@ module.exports = {
     _.mapValues(_.toNumber),
     _.some(x => !_.isNaN(x))
   ),
-  filter: ({field, min, max}) => ({
+  filter: ({ field, min, max }) => ({
     [field]: cleanFilter({
       $gte: min,
       $lte: max,

--- a/test/example-types/number.js
+++ b/test/example-types/number.js
@@ -6,11 +6,20 @@ describe('number', () => {
     it('Allows optionally either min or max', () => {
       expect(number.hasValue({ min: 1 })).to.equal(true)
       expect(number.hasValue({ max: 2 })).to.equal(true)
-    }),
-      it('Allows 0 on min and max', () => {
-        expect(number.hasValue({ min: 0 })).to.equal(true)
-        expect(number.hasValue({ max: 0 })).to.equal(true)
-      })
+    })
+    it('Allows 0 on min and max', () => {
+      expect(number.hasValue({ min: 0 })).to.equal(true)
+      expect(number.hasValue({ max: 0 })).to.equal(true)
+    })
+    it('Should handle numbers as strings', () => {
+      expect(number.hasValue({ min: '10001' })).to.equal(true)
+      expect(number.hasValue({ min: 'asda' })).to.equal(false)
+      expect(number.hasValue({})).to.equal(false)
+      expect(number.hasValue({ max: '10001' })).to.equal(true)
+      expect(number.hasValue({ max: 'asda' })).to.equal(false)
+      expect(number.hasValue({ min: '10001', max: 'asdfa' })).to.equal(true)
+      expect(number.hasValue({ min: '10asd001', max: '1001' })).to.equal(true)
+    })
   })
   describe('number.filter', () => {
     it('Should convert both min and max to valid numbers', () => {


### PR DESCRIPTION
`number` properly supports casting strings to numbers