### PR TITLE
Results example type: sort after lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ﻿# 0.8.1
+* Results example type: sort after lookups
+
+# 0.8.1
 * Remove uneccessary contexture peer dependency (which causes an issue since minor revisions are breaking in semver at 0.x)
 
 # 0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.8.3
-* Results example type: sort after lookups
+* Results example type: sort after lookups and `include` is respected now via `$project`.
 
 # 0.8.2
 * Fix typo on `tagsText` example type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -26,7 +26,7 @@ let lookupFromPopulate = getSchema =>
     }
   })
 
-let getStartRecord = (page, pageSize) => {
+let getStartRecord = ({ page, pageSize }) => {
   page = page < 1 ? 0 : page - 1
   return page * pageSize
 }

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -54,7 +54,7 @@ let getResultsQuery = (context, getSchema, startRecord) => {
   )
   // $project
   let $project = [
-    { $project: _.zipObject(include, _.times(_.constant(1), include.length)) },
+    { $project: _.countBy(_.identity, include) }
   ]
 
   return [

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -57,12 +57,12 @@ let getResultsQuery = (context, getSchema, startRecord) => {
     { $project: _.zipObject(include, _.times(_.constant(1), include.length)) },
   ]
 
-  return _.reject(_.isEmpty, [
+  return [
     ...(!sortOnJoinField ? sortSkipLimit : []),
     ...lookupFromPopulate(getSchema)(populate),
     ...(sortOnJoinField ? sortSkipLimit : []),
     ...(!_.isEmpty(include) ? $project : []),
-  ])
+  ]
 }
 
 let defaults = _.defaults({

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -48,8 +48,8 @@ let getResultsQuery = (context, getSchema, startRecord) => {
   ]
   // If sort field is a join field move $sort, $skip, and $limit to after $lookup.
   // Otherwise, place those stages first to take advantage of any indexes on that field.
-  let sortOnJoinField = _.includes(
-    _.replace(/^([^.]+)\..+$/, '$1', sortField),
+  let sortOnJoinField = _.some(
+    x => _.startsWith(`${x}.`, sortField) || sortField === x,
     _.keys(populate)
   )
   // $project

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -23,9 +23,6 @@ module.exports = {
       search(
         _.reject(_.isEmpty, [
           {
-            $sort: sort,
-          },
-          {
             $skip: startRecord,
           },
           pageSize > 0 && {
@@ -54,6 +51,9 @@ module.exports = {
               },
             }
           }, populate),
+          {
+            $sort: sort,
+          },
         ])
       ),
       search([

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -85,7 +85,6 @@ let result = async (context, search, schema, { getSchema }) => {
   ])
 
   return {
-    // TODO - handle aggregate wrapped stuff, e.g. result.result or result.result[0] etc
     response: {
       totalRecords: _.get('0.count', count),
       startRecord: startRecord + 1,

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -46,8 +46,8 @@ let getResultsQuery = (context, getSchema, startRecord) => {
       $limit: pageSize,
     },
   ]
-  // If sort field contains a '.' move $sort, $skip, and $limit to after $lookup.
-  // Otherwise, place those first to take advantage of any indexes on that field.
+  // If sort field is a join field move $sort, $skip, and $limit to after $lookup.
+  // Otherwise, place those stages first to take advantage of any indexes on that field.
   let sortOnJoinField = _.includes(
     _.replace(/^([^.]+)\..+$/, '$1', sortField),
     _.keys(populate)

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,72 +1,87 @@
 let F = require('futil-js')
 let _ = require('lodash/fp')
-let Promise = require('bluebird')
 
-module.exports = {
-  result(context, search, schema, { getSchema }) {
-    let {
-      page = 1,
-      pageSize = 10,
-      sortField = '_score',
-      sortDir = 'desc',
-      populate,
-    } = context
+let lookupFromPopulate = getSchema =>
+  F.mapIndexed((x, as) => {
+    let targetSchema = getSchema(x.schema) //|| toSingular(as), //<-- needs compromise-fp
+    if (!targetSchema)
+      throw Error(`Couldn't find schema configuration for ${x.schema}`)
+    if (!targetSchema.mongo)
+      throw Error(
+        'Populating a non mongo provider schema on a mongo provider schema is not supported'
+      )
+    let targetCollection = _.get('mongo.collection', targetSchema)
+    if (!targetCollection)
+      throw Error(
+        `The ${targetCollection} schema has a mongo configuration, but doesn't have a 'collection' property`
+      )
 
-    page -= 1
-    let startRecord = page * pageSize
-
-    let sort = {
-      [sortField]: sortDir === 'asc' ? 1 : -1,
+    return {
+      $lookup: {
+        as,
+        from: targetCollection,
+        localField: x.localField, // || '_id',
+        foreignField: x.foreignField, // || context.schema, <-- needs schema lookup
+      },
     }
+  })
 
-    return Promise.all([
-      search(
-        _.reject(_.isEmpty, [
-          {
-            $skip: startRecord,
-          },
-          pageSize > 0 && {
-            $limit: pageSize,
-          },
-          ...F.mapIndexed((x, as) => {
-            let targetSchema = getSchema(x.schema) //|| toSingular(as), //<-- needs compromise-fp
-            if (!targetSchema)
-              throw Error(`Couldn't find schema configuration for ${x.schema}`)
-            if (!targetSchema.mongo)
-              throw Error(
-                'Populating a non mongo provider schema on a mongo provider schema is not supported'
-              )
-            let targetCollection = _.get('mongo.collection', targetSchema)
-            if (!targetCollection)
-              throw Error(
-                `The ${targetCollection} schema has a mongo configuration, but doesn't have a 'collection' property`
-              )
+let getStartRecord = (page, pageSize) => {
+  page -= 1
+  return page * pageSize
+}
 
-            return {
-              $lookup: {
-                as,
-                from: targetCollection,
-                localField: x.localField, // || '_id',
-                foreignField: x.foreignField, // || context.schema, <-- needs schema lookup
-              },
-            }
-          }, populate),
-          {
-            $sort: sort,
-          },
-        ])
-      ),
-      search([
-        {
-          $group: {
-            _id: null,
-            count: {
-              $sum: 1,
-            },
-          },
-        },
-      ]),
-    ]).spread((results, count) => ({
+let getResultsQuery = (context, getSchema, startRecord) => {
+  let { pageSize, sortField, sortDir, populate, include } = context
+
+  let $sort = {
+    [sortField]: sortDir === 'asc' ? 1 : -1,
+  }
+
+  // $sort, $skip, $limit
+  let sortSkipLimit = [
+    { $sort },
+    { $skip: startRecord },
+    pageSize > 0 && {
+      $limit: pageSize,
+    },
+  ]
+  // If sort field contains a '.' move $sort, $skip, and $limit to after $lookup.
+  // Otherwise, place those first to take advantage of any indexes on that field.
+  let sortOnJoinField = /\./.test(sortField)
+  // $project
+  let $project = _.zipObject(include, _.times(_.constant(1), include.length))
+
+  return _.reject(_.isEmpty, [
+    ...(!sortOnJoinField ? sortSkipLimit : []),
+    ...lookupFromPopulate(getSchema)(populate),
+    ...(sortOnJoinField ? sortSkipLimit : []),
+    $project,
+  ])
+}
+
+let defaults = _.defaults({
+  page: 1,
+  pageSize: 10,
+  sortField: '_score',
+  sortDir: 'desc',
+  include: [],
+})
+
+// NOTE: pageSize of 0 will return all records
+module.exports = {
+  async result(context, search, schema, { getSchema }) {
+    context = defaults(context)
+    let startRecord = getStartRecord(context)
+    let resultsQuery = getResultsQuery(context, getSchema, startRecord)
+    let countQuery = [{ $group: { _id: null, count: { $sum: 1 } } }]
+
+    let [results, count] = await Promise.all([
+      search(resultsQuery),
+      search(countQuery),
+    ])
+
+    return {
       // TODO - handle aggregate wrapped stuff, e.g. result.result or result.result[0] etc
       response: {
         totalRecords: _.get('0.count', count),
@@ -74,6 +89,6 @@ module.exports = {
         endRecord: startRecord + results.length,
         results,
       },
-    }))
+    }
   },
 }

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -48,7 +48,10 @@ let getResultsQuery = (context, getSchema, startRecord) => {
   ]
   // If sort field contains a '.' move $sort, $skip, and $limit to after $lookup.
   // Otherwise, place those first to take advantage of any indexes on that field.
-  let sortOnJoinField = /\./.test(sortField)
+  let sortOnJoinField = _.includes(
+    _.replace(/^([^.]+)\..+$/, '$1', sortField),
+    _.keys(populate)
+  )
   // $project
   let $project = [
     { $project: _.zipObject(include, _.times(_.constant(1), include.length)) },

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,7 @@ var Promise = require('bluebird')
 
 // Basic function to encapsulate everything needed to run a request - tiny wrapper over raw mongo syntax
 var mongoDSL = (client, dsl) => {
-  // if (!_.get(`collections.${dsl.collection}`, client))
-  //   console.log('missing collection', await client.collections())
-  //   throw `Collection [${dsl.collection}] does not exist in the client's db!`
   var Collection = client.collection(dsl.collection)
-  // if (dsl.resultOptions)
-  //     return Collection.find(dsl.criteria, dsl.resultOptions)
-  // if (dsl.count)
-  //     return Collection.count(dsl.criteria)
   if (dsl.aggs) return Collection.aggregate(dsl.aggs).toArray()
 }
 

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -1,5 +1,132 @@
+let { expect } = require('chai')
+let {
+  defaults,
+  lookupFromPopulate,
+  getResultsQuery,
+  getStartRecord,
+} = require('../../src/example-types/results')
+
+let getSchema = collection => ({ mongo: { collection } })
+
 describe('results', () => {
-  it.skip('should support populate as $lookup', () => {
-    // Add test for result function
+  describe('lookupFromPopulate', () => {
+    it('should translate populate object into an array of $lookup objects', () => {
+      let populate = {
+        user: {
+          schema: 'user',
+          localField: 'user',
+          foreignField: '_id',
+        },
+        organization: {
+          schema: 'organization',
+          localField: 'organization',
+          foreignField: '_id',
+        },
+      }
+      expect(lookupFromPopulate(getSchema)(populate)).to.deep.equal([
+        {
+          $lookup: {
+            as: 'user',
+            from: 'user',
+            localField: 'user',
+            foreignField: '_id',
+          },
+        },
+        {
+          $lookup: {
+            as: 'organization',
+            from: 'organization',
+            localField: 'organization',
+            foreignField: '_id',
+          },
+        },
+      ])
+    })
+  })
+  describe('getStartRecord', () => {
+    it('should return 0 if page is 1', () => {
+      expect(getStartRecord(1, 10)).to.equal(0)
+    })
+    it('should return 0 if page is < 1', () => {
+      expect(getStartRecord(0, 10)).to.equal(0)
+    })
+    it('should return 10 if page is 2', () => {
+      expect(getStartRecord(2, 10)).to.equal(10)
+    })
+  })
+  describe('getResultsQuery', () => {
+    it('should put $sort, $skip, $limit first in pipeline', () => {
+      let context = defaults({
+        key: 'results',
+        type: 'results',
+        sortField: 'createdAt',
+        include: ['name', 'user', 'type', 'updatedAt'],
+        sortDir: 'asc',
+        populate: {
+          user: {
+            schema: 'user',
+            localField: 'user',
+            foreignField: '_id',
+          },
+        },
+      })
+      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+        { $sort: { createdAt: 1 } },
+        { $skip: 0 },
+        { $limit: 10 },
+        {
+          $lookup: {
+            as: 'user',
+            from: 'user',
+            localField: 'user',
+            foreignField: '_id',
+          },
+        },
+        { $project: { name: 1, user: 1, type: 1, updatedAt: 1 } },
+      ])
+    })
+    it('should sort descending', () => {
+      let context = defaults({
+        key: 'results',
+        type: 'results',
+        sortField: 'createdAt',
+        sortDir: 'desc',
+      })
+      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+        { $sort: { createdAt: -1 } },
+        { $skip: 0 },
+        { $limit: 10 },
+      ])
+    })
+    it('should put $sort, $skip, $limit first after $lookup', () => {
+      let context = defaults({
+        key: 'results',
+        type: 'results',
+        sortField: 'user.firstName',
+        include: ['user.firstName', 'user', 'type', 'updatedAt'],
+        sortDir: 'asc',
+        populate: {
+          user: {
+            schema: 'user',
+            localField: 'user',
+            foreignField: '_id',
+          },
+        },
+      })
+      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+        {
+          $lookup: {
+            as: 'user',
+            from: 'user',
+            localField: 'user',
+            foreignField: '_id',
+          },
+        },
+        { $sort: { 'user.firstName': 1 } },
+        { $skip: 0 },
+        { $limit: 10 },
+        { $project: { 'user.firstName': 1, user: 1, type: 1, updatedAt: 1 } },
+      ])
+    })
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -45,13 +45,16 @@ describe('results', () => {
   })
   describe('getStartRecord', () => {
     it('should return 0 if page is 1', () => {
-      expect(getStartRecord(1, 10)).to.equal(0)
+      let context = { page: 1, pageSize: 10 }
+      expect(getStartRecord(context)).to.equal(0)
     })
     it('should return 0 if page is < 1', () => {
-      expect(getStartRecord(0, 10)).to.equal(0)
+      let context = { page: 0, pageSize: 10 }
+      expect(getStartRecord(context)).to.equal(0)
     })
     it('should return 10 if page is 2', () => {
-      expect(getStartRecord(2, 10)).to.equal(10)
+      let context = { page: 2, pageSize: 10 }
+      expect(getStartRecord(context)).to.equal(10)
     })
   })
   describe('getResultsQuery', () => {


### PR DESCRIPTION
This way we can use fields from the lookups to sort the results

- [ ] Write tests for the `results` example type.