### PR TITLE
Fixes for results type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.8.4
+* Results example type: Removed default `$sort`. Fixed `$limit` when pageSize is 0.
+
 # 0.8.3
 * Results example type: sort after lookups and `include` is respected now via `$project`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -34,18 +34,18 @@ let getStartRecord = ({ page, pageSize }) => {
 let getResultsQuery = (context, getSchema, startRecord) => {
   let { pageSize, sortField, sortDir, populate, include } = context
 
-  let $sort = {
-    [sortField]: sortDir === 'asc' ? 1 : -1,
-  }
-
   // $sort, $skip, $limit
-  let sortSkipLimit = [
-    { $sort },
-    { $skip: startRecord },
-    pageSize > 0 && {
-      $limit: pageSize,
+  let $sort = {
+    $sort: {
+      [sortField]: sortDir === 'asc' ? 1 : -1,
     },
-  ]
+  }
+  let $limit = { $limit: pageSize }
+  let sortSkipLimit = _.compact([
+    sortField && $sort,
+    { $skip: startRecord },
+    pageSize > 0 && $limit,
+  ])
   // If sort field is a join field move $sort, $skip, and $limit to after $lookup.
   // Otherwise, place those stages first to take advantage of any indexes on that field.
   let sortOnJoinField = _.some(
@@ -66,7 +66,6 @@ let getResultsQuery = (context, getSchema, startRecord) => {
 let defaults = _.defaults({
   page: 1,
   pageSize: 10,
-  sortField: '_score',
   sortDir: 'desc',
   include: [],
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -161,5 +161,27 @@ describe('results', () => {
         { $limit: 10 },
       ])
     })
+    it('should not have $limit stage if pageSize is 0', () => {
+      let context = defaults({
+        key: 'results',
+        type: 'results',
+        sortField: 'createdAt',
+        pageSize: 0,
+      })
+      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+        { $sort: { createdAt: -1 } },
+        { $skip: 0 },
+      ])
+    })
+    it('should not have $sort stage if sortField is missing', () => {
+      let context = defaults({
+        key: 'results',
+        type: 'results',
+      })
+      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+        { $skip: 0 },
+        { $limit: 10 },
+      ])
+    })
   })
 })


### PR DESCRIPTION
Results example type: Removed default `$sort`. Fixed `$limit` when pageSize is 0.