### PR TITLE
feature/47 - use futil regex builder in facet type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.9.3
-* Moved from `futil-js` to lastest `futil` (just package rename + version bump)
+* Move from `futil-js` to lastest `futil` (just package rename + version bump)
 * Leverage futil regex methods
+* Change internal naming from `context` to `node`
 
 # 0.9.2
 * Make sure to use the populate key when `$unwind`ing a `$lookup`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.9.3
+* Leverage new futil export regex builders in the facet options filter
 * Move from `futil-js` to lastest `futil` (just package rename + version bump)
-* Leverage futil regex methods
 * Change internal naming from `context` to `node`
 
 # 0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.3
+* Moved from `futil-js` to lastest `futil` (just package rename + version bump)
+* Leverage futil regex methods
+
 # 0.9.2
 * Make sure to use the populate key when `$unwind`ing a `$lookup`.
 

--- a/integration-test/example-types/textAndMongoId.js
+++ b/integration-test/example-types/textAndMongoId.js
@@ -58,8 +58,8 @@ describe('Grouping text and mongoId', () => {
         type: 'results'
       }]
     }
-    let context = await process(dsl, { debug: true })
-    let response = _.last(context.items).context.response
+    let result = await process(dsl, { debug: true })
+    let response = _.last(result.items).context.response
     expect(response.totalRecords).to.equal(1)
     expect(response.results[0]._id.toString()).to.equal(id.toString())
   })
@@ -99,8 +99,8 @@ describe('Grouping text and mongoId', () => {
         }
       }]
     }
-    let context = await process(dsl, { debug: true })
-    let response = _.last(context.items).context.response
+    let result = await process(dsl, { debug: true })
+    let response = _.last(result.items).context.response
     expect(response.totalRecords).to.equal(1)
     expect(response.results[0]._id.toString()).to.equal(id.toString())
     expect(response.results[0].child[0]._id.toString()).to.equal(id2.toString())

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
     "bluebird": "^3.5.0",
-    "futil-js": "^1.31.0",
+    "futil-js": "^1.59.0",
     "include-all": "^4.0.3",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@elastic/datemath": "^2.3.0",
     "bluebird": "^3.5.0",
-    "futil-js": "^1.59.0",
+    "futil": "^1.63.0",
     "include-all": "^4.0.3",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/date.js
+++ b/src/example-types/date.js
@@ -3,7 +3,7 @@ let moment = require('moment')
 let datemath = require('@elastic/datemath')
 
 module.exports = {
-  hasValue: context => context.from || context.to,
+  hasValue: node => node.from || node.to,
   filter({ from, to, field, useDateMath, dateType = 'date' }) {
     if (useDateMath) {
       if (from === 'thisQuarter') {

--- a/src/example-types/date.js
+++ b/src/example-types/date.js
@@ -1,4 +1,4 @@
-let _ = require('lodash')
+let F = require('futil')
 let moment = require('moment')
 let datemath = require('@elastic/datemath')
 
@@ -36,13 +36,10 @@ module.exports = {
     }[dateType]
 
     return {
-      [field]: _.pickBy(
-        {
-          $gte: format(from),
-          $lte: format(to),
-        },
-        _.identity
-      ),
+      [field]: F.compactObject({
+        $gte: format(from),
+        $lte: format(to)
+      })
     }
-  },
+  }
 }

--- a/src/example-types/date.js
+++ b/src/example-types/date.js
@@ -38,8 +38,8 @@ module.exports = {
     return {
       [field]: F.compactObject({
         $gte: format(from),
-        $lte: format(to)
-      })
+        $lte: format(to),
+      }),
     }
-  }
+  },
 }

--- a/src/example-types/exists.js
+++ b/src/example-types/exists.js
@@ -5,14 +5,14 @@ module.exports = {
       ? {
           $and: [
             { [field]: { $exists: value, $ne: '' } },
-            { [field]: { $ne: null } }
-          ]
+            { [field]: { $ne: null } },
+          ],
         }
       : {
           $or: [
             { [field]: { $exists: false } },
             { [field]: '' },
-            { [field]: null }
-          ]
-        }
+            { [field]: null },
+          ],
+        },
 }

--- a/src/example-types/exists.js
+++ b/src/example-types/exists.js
@@ -4,32 +4,15 @@ module.exports = {
     value
       ? {
           $and: [
-            {
-              [field]: {
-                $exists: value,
-                $ne: '',
-              },
-            },
-            {
-              [field]: {
-                $ne: null,
-              },
-            },
-          ],
+            { [field]: { $exists: value, $ne: '' } },
+            { [field]: { $ne: null } }
+          ]
         }
       : {
           $or: [
-            {
-              [field]: {
-                $exists: false,
-              },
-            },
-            {
-              [field]: '',
-            },
-            {
-              [field]: null,
-            },
-          ],
-        },
+            { [field]: { $exists: false } },
+            { [field]: '' },
+            { [field]: null }
+          ]
+        }
 }

--- a/src/example-types/exists.js
+++ b/src/example-types/exists.js
@@ -1,17 +1,17 @@
 module.exports = {
   hasValue: () => true,
-  filter: context =>
-    context.value
+  filter: ({ field, value }) =>
+    value
       ? {
           $and: [
             {
-              [context.field]: {
-                $exists: context.value,
+              [field]: {
+                $exists: value,
                 $ne: '',
               },
             },
             {
-              [context.field]: {
+              [field]: {
                 $ne: null,
               },
             },
@@ -20,15 +20,15 @@ module.exports = {
       : {
           $or: [
             {
-              [context.field]: {
+              [field]: {
                 $exists: false,
               },
             },
             {
-              [context.field]: '',
+              [field]: '',
             },
             {
-              [context.field]: null,
+              [field]: null,
             },
           ],
         },

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -1,15 +1,7 @@
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
 let { ObjectID } = require('mongodb')
-
-let buildRegex = _.flow(
-  _.replace(/\s\s+/g, ' '),
-  _.trim,
-  _.split(' '),
-  _.map(x => `(?=.*${x}.*)`),
-  _.join(''),
-  x => `.*${x}.*`
-)
+let F = require('futil-js')
 
 module.exports = {
   hasValue: _.get('values.length'),
@@ -39,7 +31,7 @@ module.exports = {
           context.optionsFilter && {
             $match: {
               _id: {
-                $regex: buildRegex(context.optionsFilter),
+                $regex: F.wordsToRegexp(context.optionsFilter),
                 $options: 'i',
               },
             },

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -1,7 +1,7 @@
 let _ = require('lodash/fp')
 let Promise = require('bluebird')
 let { ObjectID } = require('mongodb')
-let F = require('futil-js')
+let F = require('futil')
 
 module.exports = {
   hasValue: _.get('values.length'),

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -8,8 +8,8 @@ module.exports = {
     [node.field]: {
       [node.mode === 'exclude' ? '$nin' : '$in']: node.isMongoId
         ? _.map(ObjectID, node.values)
-        : node.values
-    }
+        : node.values,
+    },
   }),
   result: (node, search) =>
     Promise.all([
@@ -24,20 +24,20 @@ module.exports = {
             $match: {
               _id: {
                 $regex: F.wordsToRegexp(node.optionsFilter),
-                $options: 'i'
-              }
-            }
+                $options: 'i',
+              },
+            },
           },
-          node.size !== 0 && { $limit: node.size || 10 }
+          node.size !== 0 && { $limit: node.size || 10 },
         ])
       ),
       search([
         { $unwind: `$${node.field}` },
         { $group: { _id: `$${node.field}` } },
-        { $group: { _id: 1, count: { $sum: 1 } } }
-      ])
+        { $group: { _id: 1, count: { $sum: 1 } } },
+      ]),
     ]).then(([options, cardinality]) => ({
       cardinality: _.get('0.count', cardinality),
-      options: _.map(x => ({ name: x._id, count: x.count }), options)
-    }))
+      options: _.map(x => ({ name: x._id, count: x.count }), options),
+    })),
 }

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -5,47 +5,47 @@ let F = require('futil')
 
 module.exports = {
   hasValue: _.get('values.length'),
-  filter: context => ({
-    [context.field]: {
-      [context.mode === 'exclude' ? '$nin' : '$in']: context.isMongoId
-        ? _.map(ObjectID, context.values)
-        : context.values,
+  filter: node => ({
+    [node.field]: {
+      [node.mode === 'exclude' ? '$nin' : '$in']: node.isMongoId
+        ? _.map(ObjectID, node.values)
+        : node.values,
     },
   }),
-  result: (context, search) =>
+  result: (node, search) =>
     Promise.all([
       search(
         _.compact([
           // Unwind allows supporting array and non array fields - for non arrays, it will treat as an array with 1 value
           // https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#non-array-field-path
-          { $unwind: `$${context.field}` },
+          { $unwind: `$${node.field}` },
           {
             $group: {
-              _id: `$${context.field}`,
+              _id: `$${node.field}`,
               count: {
                 $sum: 1,
               },
             },
           },
           { $sort: { count: -1 } },
-          context.optionsFilter && {
+          node.optionsFilter && {
             $match: {
               _id: {
-                $regex: F.wordsToRegexp(context.optionsFilter),
+                $regex: F.wordsToRegexp(node.optionsFilter),
                 $options: 'i',
               },
             },
           },
-          context.size !== 0 && {
-            $limit: context.size || 10,
+          node.size !== 0 && {
+            $limit: node.size || 10,
           },
         ])
       ),
       search([
-        { $unwind: `$${context.field}` },
+        { $unwind: `$${node.field}` },
         {
           $group: {
-            _id: `$${context.field}`,
+            _id: `$${node.field}`,
           },
         },
         {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -1,7 +1,6 @@
-let _ = require('lodash/fp')
-let Promise = require('bluebird')
-let { ObjectID } = require('mongodb')
 let F = require('futil')
+let _ = require('lodash/fp')
+let { ObjectID } = require('mongodb')
 
 module.exports = {
   hasValue: _.get('values.length'),
@@ -9,8 +8,8 @@ module.exports = {
     [node.field]: {
       [node.mode === 'exclude' ? '$nin' : '$in']: node.isMongoId
         ? _.map(ObjectID, node.values)
-        : node.values,
-    },
+        : node.values
+    }
   }),
   result: (node, search) =>
     Promise.all([
@@ -19,52 +18,26 @@ module.exports = {
           // Unwind allows supporting array and non array fields - for non arrays, it will treat as an array with 1 value
           // https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/#non-array-field-path
           { $unwind: `$${node.field}` },
-          {
-            $group: {
-              _id: `$${node.field}`,
-              count: {
-                $sum: 1,
-              },
-            },
-          },
+          { $group: { _id: `$${node.field}`, count: { $sum: 1 } } },
           { $sort: { count: -1 } },
           node.optionsFilter && {
             $match: {
               _id: {
                 $regex: F.wordsToRegexp(node.optionsFilter),
-                $options: 'i',
-              },
-            },
+                $options: 'i'
+              }
+            }
           },
-          node.size !== 0 && {
-            $limit: node.size || 10,
-          },
+          node.size !== 0 && { $limit: node.size || 10 }
         ])
       ),
       search([
         { $unwind: `$${node.field}` },
-        {
-          $group: {
-            _id: `$${node.field}`,
-          },
-        },
-        {
-          $group: {
-            _id: 1,
-            count: {
-              $sum: 1,
-            },
-          },
-        },
-      ]),
-    ]).spread((options, cardinality) => ({
+        { $group: { _id: `$${node.field}` } },
+        { $group: { _id: 1, count: { $sum: 1 } } }
+      ])
+    ]).then(([options, cardinality]) => ({
       cardinality: _.get('0.count', cardinality),
-      options: _.map(
-        x => ({
-          name: x._id,
-          count: x.count,
-        }),
-        options
-      ),
-    })),
+      options: _.map(x => ({ name: x._id, count: x.count }), options)
+    }))
 }

--- a/src/example-types/mongoId.js
+++ b/src/example-types/mongoId.js
@@ -1,12 +1,12 @@
 let _ = require('lodash/fp')
-let ObjectID = require('mongodb').ObjectID
+let { ObjectID } = require('mongodb')
 
 module.exports = {
   hasValue: node => node.values || node.value,
   filter: node => ({
     [node.field]: {
       [node.mode === 'exclude' ? '$nin' : '$in']: _.map(
-        x => new ObjectID(x),
+        ObjectID,
         node.values || [node.value]
       ),
     },

--- a/src/example-types/mongoId.js
+++ b/src/example-types/mongoId.js
@@ -2,12 +2,12 @@ let _ = require('lodash/fp')
 let ObjectID = require('mongodb').ObjectID
 
 module.exports = {
-  hasValue: context => context.values || context.value,
-  filter: context => ({
-    [context.field]: {
-      [context.mode === 'exclude' ? '$nin' : '$in']: _.map(
+  hasValue: node => node.values || node.value,
+  filter: node => ({
+    [node.field]: {
+      [node.mode === 'exclude' ? '$nin' : '$in']: _.map(
         x => new ObjectID(x),
-        context.values || [context.value]
+        node.values || [node.value]
       ),
     },
   }),

--- a/src/example-types/number.js
+++ b/src/example-types/number.js
@@ -1,4 +1,4 @@
-var _ = require('lodash/fp')
+let _ = require('lodash/fp')
 
 let predicate = x =>
   (_.isString(x) || _.isNumber(x)) && x !== '' && _.isFinite(_.toNumber(x))

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,4 +1,4 @@
-let F = require('futil-js')
+let F = require('futil')
 let _ = require('lodash/fp')
 
 let lookupFromPopulate = getSchema =>

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -34,7 +34,7 @@ let convertPopulate = getSchema =>
             as,
             from: targetCollection,
             localField: x.localField, // || '_id',
-            foreignField: x.foreignField, // || context.schema, <-- needs schema lookup
+            foreignField: x.foreignField, // || node.schema, <-- needs schema lookup
           },
         },
       ]
@@ -59,8 +59,8 @@ let projectFromInclude = include =>
     _.countBy(_.identity)
   )(include)
 
-let getResultsQuery = (context, getSchema, startRecord) => {
-  let { pageSize, sortField, sortDir, populate, include } = context
+let getResultsQuery = (node, getSchema, startRecord) => {
+  let { pageSize, sortField, sortDir, populate, include } = node
 
   // $sort, $skip, $limit
   let $sort = {
@@ -100,10 +100,10 @@ let defaults = _.defaults({
   include: [],
 })
 
-let result = async (context, search, schema, { getSchema }) => {
-  context = defaults(context)
-  let startRecord = getStartRecord(context)
-  let resultsQuery = getResultsQuery(context, getSchema, startRecord)
+let result = async (node, search, schema, { getSchema }) => {
+  node = defaults(node)
+  let startRecord = getStartRecord(node)
+  let resultsQuery = getResultsQuery(node, getSchema, startRecord)
   let countQuery = [{ $group: { _id: null, count: { $sum: 1 } } }]
 
   let [results, count] = await Promise.all([

--- a/src/example-types/statistical.js
+++ b/src/example-types/statistical.js
@@ -1,4 +1,4 @@
-let _ = require('lodash')
+let _ = require('lodash/fp')
 
 module.exports = {
   result: async ({ field }, search) =>
@@ -8,26 +8,12 @@ module.exports = {
           $group: {
             _id: {},
             count: { $sum: 1 },
-            max: {
-              $max: `$${field}`,
-            },
-            min: {
-              $min: `$${field}`,
-            },
-            avg: {
-              $avg: `$${field}`,
-            },
-            sum: {
-              $sum: `$${field}`,
-            },
-          },
-        },
+            max: { $max: `$${field}` },
+            min: { $min: `$${field}` },
+            avg: { $avg: `$${field}` },
+            sum: { $sum: `$${field}` }
+          }
+        }
       ])
-    ) || {
-      count: 0,
-      avg: 0,
-      max: 0,
-      min: 0,
-      sum: 0,
-    },
+    ) || { count: 0, avg: 0, max: 0, min: 0, sum: 0 }
 }

--- a/src/example-types/statistical.js
+++ b/src/example-types/statistical.js
@@ -11,9 +11,9 @@ module.exports = {
             max: { $max: `$${field}` },
             min: { $min: `$${field}` },
             avg: { $avg: `$${field}` },
-            sum: { $sum: `$${field}` }
-          }
-        }
+            sum: { $sum: `$${field}` },
+          },
+        },
       ])
-    ) || { count: 0, avg: 0, max: 0, min: 0, sum: 0 }
+    ) || { count: 0, avg: 0, max: 0, min: 0, sum: 0 },
 }

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -1,5 +1,5 @@
-let _ = require('lodash/fp')
 let F = require('futil')
+let _ = require('lodash/fp')
 
 let joinmap = {
   all: '$and',
@@ -8,7 +8,7 @@ let joinmap = {
 }
 
 module.exports = {
-  hasValue: x => F.cascade(['value', 'values.length'])(x),
+  hasValue: F.cascade(['value', 'values.length']),
   filter: node => ({
     [joinmap[node.join || 'all']]: _.map(
       val => ({

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -9,10 +9,10 @@ let joinmap = {
 
 module.exports = {
   hasValue: x => F.cascade(['value', 'values.length'])(x),
-  filter: context => ({
-    [joinmap[context.join || 'all']]: _.map(
+  filter: node => ({
+    [joinmap[node.join || 'all']]: _.map(
       val => ({
-        [context.field]: {
+        [node.field]: {
           $regex: {
             containsWord: val,
             startsWith: `^${val}`,
@@ -21,11 +21,11 @@ module.exports = {
             wordEndsWith: `${val}\\b`,
             is: `^${val}$`,
             containsExact: `\\b${val}\\b`,
-          }[context.operator],
+          }[node.operator],
           $options: 'i',
         },
       }),
-      context.values || [context.value]
+      node.values || [node.value]
     ),
   }),
 }

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -1,5 +1,5 @@
 let _ = require('lodash/fp')
-let F = require('futil-js')
+let F = require('futil')
 
 let joinmap = {
   all: '$and',

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ var MongoProvider = config => ({
     [`$${group.join === 'not' ? 'nor' : group.join}`]: filters,
   }),
   types: config.types,
-  runSearch(options, context, schema, filters, aggs) {
+  runSearch(options, node, schema, filters, aggs) {
     var client = config.getClient()
 
     var request = {
@@ -27,7 +27,7 @@ var MongoProvider = config => ({
     }
 
     // Log Request
-    context._meta.requests.push(request)
+    node._meta.requests.push(request)
 
     var result = Promise.resolve(mongoDSL(client, request))
     return result.tap(results => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,20 @@
-// var _ = require('lodash/fp')
-var Promise = require('bluebird')
+let Promise = require('bluebird')
 
 // Basic function to encapsulate everything needed to run a request - tiny wrapper over raw mongo syntax
-var mongoDSL = (client, dsl) => {
-  var Collection = client.collection(dsl.collection)
+let mongoDSL = (client, dsl) => {
+  let Collection = client.collection(dsl.collection)
   if (dsl.aggs) return Collection.aggregate(dsl.aggs).toArray()
 }
 
-var MongoProvider = config => ({
+let MongoProvider = config => ({
   groupCombinator: (group, filters) => ({
     [`$${group.join === 'not' ? 'nor' : group.join}`]: filters,
   }),
   types: config.types,
   runSearch(options, node, schema, filters, aggs) {
-    var client = config.getClient()
+    let client = config.getClient()
 
-    var request = {
+    let request = {
       // criteria: filters,
       collection: schema.mongo.collection,
       aggs: [
@@ -29,7 +28,7 @@ var MongoProvider = config => ({
     // Log Request
     node._meta.requests.push(request)
 
-    var result = Promise.resolve(mongoDSL(client, request))
+    let result = Promise.resolve(mongoDSL(client, request))
     return result.tap(results => {
       // Log response
       request.response = results

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -64,7 +64,7 @@ describe('facet', () => {
       expect(filterAgg).to.deep.equal({
         $match: {
           _id: {
-            $regex: '.*(?=.*cable.*).*',
+            $regex: '(?=.*cable)',
             $options: 'i',
           },
         },
@@ -85,7 +85,7 @@ describe('facet', () => {
       expect(filterAgg).to.deep.equal({
         $match: {
           _id: {
-            $regex: '.*(?=.*dis.*)(?=.*comp.*).*',
+            $regex: '(?=.*dis)(?=.*comp)',
             $options: 'i',
           },
         },

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -64,7 +64,7 @@ describe('facet', () => {
       expect(filterAgg).to.deep.equal({
         $match: {
           _id: {
-            $regex: '(?=.*cable)',
+            $regex: '.*(?=.*cable.*).*',
             $options: 'i',
           },
         },
@@ -85,7 +85,7 @@ describe('facet', () => {
       expect(filterAgg).to.deep.equal({
         $match: {
           _id: {
-            $regex: '(?=.*dis)(?=.*comp)',
+            $regex: '.*(?=.*dis.*)(?=.*comp.*).*',
             $options: 'i',
           },
         },

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -4,14 +4,14 @@ let facet = require('../../src/example-types/facet')
 
 describe('facet', () => {
   describe('facet.hasValue', () => {
-    it('Should allow contexts with values', () => {
+    it('Should allow nodes with values', () => {
       expect(
         facet.hasValue({
           values: [1, 2],
         })
       ).to.equal(2)
     })
-    it('Should not allow contexts with values', () => {
+    it('Should not allow nodes with values', () => {
       expect(
         facet.hasValue({
           values: [],
@@ -27,39 +27,39 @@ describe('facet', () => {
     }
     it('should call the search function and wait for it', async () => {
       queries = []
-      let context = {
+      let node = {
         field: 'myField',
       }
-      let result = await facet.result(context, search)
+      let result = await facet.result(node, search)
       expect(result.options.length).to.equal(3)
       expect(_.every(x => _.isNumber(x.count), result.options)).to.equal(true)
     })
     it('should default the limit query to 10 if size is not provided', async () => {
       queries = []
-      let context = {
+      let node = {
         field: 'myField',
       }
-      await facet.result(context, search)
+      await facet.result(node, search)
       let limitAgg = _.find('$limit', queries[0])
       expect(limitAgg.$limit).to.equal(10)
     })
     it('should allow unlimited queries', async () => {
       queries = []
-      let context = {
+      let node = {
         field: 'myField',
         size: 0,
       }
-      await facet.result(context, search)
+      await facet.result(node, search)
       let limitAgg = _.find('$limit', queries[0])
       expect(limitAgg).to.be.undefined
     })
     it('should support optionsFilter', async () => {
       queries = []
-      let context = {
+      let node = {
         field: 'myField',
         optionsFilter: 'cable',
       }
-      await facet.result(context, search)
+      await facet.result(node, search)
       let filterAgg = _.find('$match', queries[0])
       expect(filterAgg).to.deep.equal({
         $match: {
@@ -76,11 +76,11 @@ describe('facet', () => {
     })
     it('should support optionsFilter with multiple words and spaces', async () => {
       queries = []
-      let context = {
+      let node = {
         field: 'categoriesInfo',
         optionsFilter: '  dis  comp    ',
       }
-      await facet.result(context, search)
+      await facet.result(node, search)
       let filterAgg = _.find('$match', queries[0])
       expect(filterAgg).to.deep.equal({
         $match: {
@@ -96,11 +96,11 @@ describe('facet', () => {
       expect(limitIndex > filterIndex).to.be.true
     })
     it('should support isMongoId', async () => {
-      let context = {
+      let node = {
         field: 'field',
         values: ['5a4ea8052c635b002ade8e45', '5a4ea8052c635b002ade8e45'],
       }
-      let result = await facet.filter(context)
+      let result = await facet.filter(node)
       expect(result.field.$in.map(x => x.toString())).to.deep.equal([
         '5a4ea8052c635b002ade8e45',
         '5a4ea8052c635b002ade8e45',

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -67,21 +67,21 @@ describe('results', () => {
   })
   describe('getStartRecord', () => {
     it('should return 0 if page is 1', () => {
-      let context = { page: 1, pageSize: 10 }
-      expect(getStartRecord(context)).to.equal(0)
+      let node = { page: 1, pageSize: 10 }
+      expect(getStartRecord(node)).to.equal(0)
     })
     it('should return 0 if page is < 1', () => {
-      let context = { page: 0, pageSize: 10 }
-      expect(getStartRecord(context)).to.equal(0)
+      let node = { page: 0, pageSize: 10 }
+      expect(getStartRecord(node)).to.equal(0)
     })
     it('should return 10 if page is 2', () => {
-      let context = { page: 2, pageSize: 10 }
-      expect(getStartRecord(context)).to.equal(10)
+      let node = { page: 2, pageSize: 10 }
+      expect(getStartRecord(node)).to.equal(10)
     })
   })
   describe('getResultsQuery', () => {
     it('should put $sort, $skip, $limit first in pipeline', () => {
-      let context = defaults({
+      let node = defaults({
         key: 'results',
         type: 'results',
         sortField: 'createdAt',
@@ -95,7 +95,7 @@ describe('results', () => {
           },
         },
       })
-      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+      expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         { $sort: { createdAt: 1 } },
         { $skip: 0 },
         { $limit: 10 },
@@ -111,7 +111,7 @@ describe('results', () => {
       ])
     })
     it('should put $sort, $skip, $limit first in pipeline where sort field is not part of a join', () => {
-      let context = defaults({
+      let node = defaults({
         key: 'results',
         type: 'results',
         sortField: 'metrics.sessionsCount',
@@ -125,7 +125,7 @@ describe('results', () => {
           },
         },
       })
-      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+      expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         { $sort: { 'metrics.sessionsCount': 1 } },
         { $skip: 0 },
         { $limit: 10 },
@@ -141,7 +141,7 @@ describe('results', () => {
       ])
     })
     it('should put $sort, $skip, $limit first after $lookup', () => {
-      let context = defaults({
+      let node = defaults({
         key: 'results',
         type: 'results',
         sortField: 'user.firstName',
@@ -155,7 +155,7 @@ describe('results', () => {
           },
         },
       })
-      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+      expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         {
           $lookup: {
             as: 'user',
@@ -171,36 +171,36 @@ describe('results', () => {
       ])
     })
     it('should sort descending and skip $lookup and $project', () => {
-      let context = defaults({
+      let node = defaults({
         key: 'results',
         type: 'results',
         sortField: 'createdAt',
         sortDir: 'desc',
       })
-      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+      expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         { $sort: { createdAt: -1 } },
         { $skip: 0 },
         { $limit: 10 },
       ])
     })
     it('should not have $limit stage if pageSize is 0', () => {
-      let context = defaults({
+      let node = defaults({
         key: 'results',
         type: 'results',
         sortField: 'createdAt',
         pageSize: 0,
       })
-      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+      expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         { $sort: { createdAt: -1 } },
         { $skip: 0 },
       ])
     })
     it('should not have $sort stage if sortField is missing', () => {
-      let context = defaults({
+      let node = defaults({
         key: 'results',
         type: 'results',
       })
-      expect(getResultsQuery(context, getSchema, 0)).to.deep.equal([
+      expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         { $skip: 0 },
         { $limit: 10 },
       ])

--- a/types.js
+++ b/types.js
@@ -1,4 +1,4 @@
-let F = require('futil-js')
+let F = require('futil')
 
 module.exports = (config = {}) =>
   F.mapValuesIndexed(


### PR DESCRIPTION
Fixes #47 
Fixes #25 

### Description
* Move from `futil-js` to lastest `futil` (just package rename + version bump)
* Leverage new `futil` export regex builders in the facet options filter
* Change internal naming from `context` to `node`