### PR TITLE
Fix hasValue for text type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.4
+* Make sure `hasValue` takes into account empty strings for `text` type.
+
 # 0.9.3
 * Leverage new futil export regex builders in the facet options filter
 * Move from `futil-js` to lastest `futil` (just package rename + version bump)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -10,6 +10,8 @@ let joinmap = {
 // Convert to an array, strip empty strings, and determine if there are any values
 let hasValue = _.flow(
   // NOTE: Don't change the below, otherwise things will explode!
+  // Cascade can take a third arg which causes this to behave weird (since hasValue is actually called with extra args like the schema, etc)
+  // See https://github.com/smartprocure/futil-js/issues/218
   x => F.cascade(['value', 'values'], x),
   _.defaultTo([]),
   _.castArray,

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -9,11 +9,13 @@ let joinmap = {
 
 // Convert to an array, strip empty strings, and determine if there are any values
 let hasValue = _.flow(
-  F.cascade(['value', 'values']),
+  // NOTE: Don't change the below, otherwise things will explode!
+  x => F.cascade(['value', 'values'], x),
+  _.defaultTo([]),
   _.castArray,
   _.remove(_.eq('')),
   _.size,
-  x => x >= 1
+  x => x >= 1,
 )
 
 module.exports = {

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -15,7 +15,7 @@ let hasValue = _.flow(
   _.castArray,
   _.remove(_.eq('')),
   _.size,
-  x => x >= 1,
+  x => x >= 1
 )
 
 module.exports = {

--- a/src/example-types/text.js
+++ b/src/example-types/text.js
@@ -7,8 +7,17 @@ let joinmap = {
   none: '$nor',
 }
 
+// Convert to an array, strip empty strings, and determine if there are any values
+let hasValue = _.flow(
+  F.cascade(['value', 'values']),
+  _.castArray,
+  _.remove(_.eq('')),
+  _.size,
+  x => x >= 1
+)
+
 module.exports = {
-  hasValue: F.cascade(['value', 'values.length']),
+  hasValue,
   filter: node => ({
     [joinmap[node.join || 'all']]: _.map(
       val => ({

--- a/test/example-types/text.js
+++ b/test/example-types/text.js
@@ -5,38 +5,50 @@ describe('text', () => {
   describe('text.hasValue', () => {
     it('should detect a value', () => {
       expect(
-        !!text.hasValue({
-          type: 'text',
-          field: 'test',
-          values: ['asdf'],
-        }, {})
+        !!text.hasValue(
+          {
+            type: 'text',
+            field: 'test',
+            values: ['asdf'],
+          },
+          {}
+        )
       ).to.be.true
     })
     it('should detect if values is empty', () => {
       expect(
-        !!text.hasValue({
-          type: 'text',
-          field: 'test',
-          values: [],
-        }, {})
+        !!text.hasValue(
+          {
+            type: 'text',
+            field: 'test',
+            values: [],
+          },
+          {}
+        )
       ).to.be.false
     })
     it('should detect if values only contains an empty string', () => {
       expect(
-        !!text.hasValue({
-          type: 'text',
-          field: 'test',
-          values: [''],
-        }, {})
+        !!text.hasValue(
+          {
+            type: 'text',
+            field: 'test',
+            values: [''],
+          },
+          {}
+        )
       ).to.be.false
     })
     it('should detect if value is the empty string', () => {
       expect(
-        !!text.hasValue({
-          type: 'text',
-          field: 'test',
-          value: '',
-        }, {})
+        !!text.hasValue(
+          {
+            type: 'text',
+            field: 'test',
+            value: '',
+          },
+          {}
+        )
       ).to.be.false
     })
   }),

--- a/test/example-types/text.js
+++ b/test/example-types/text.js
@@ -3,7 +3,7 @@ let text = require('../../src/example-types/text')
 
 describe('text', () => {
   describe('text.hasValue', () => {
-    it('should check for values', () => {
+    it('should detect a value', () => {
       expect(
         !!text.hasValue({
           type: 'text',
@@ -11,11 +11,22 @@ describe('text', () => {
           values: ['asdf'],
         })
       ).to.be.true
+    })
+    it('should detect missing value', () => {
       expect(
         !!text.hasValue({
           type: 'text',
           field: 'test',
           values: [],
+        })
+      ).to.be.false
+    })
+    it('should detect missing value if given empty string', () => {
+      expect(
+        !!text.hasValue({
+          type: 'text',
+          field: 'test',
+          values: [''],
         })
       ).to.be.false
     })

--- a/test/example-types/text.js
+++ b/test/example-types/text.js
@@ -9,25 +9,34 @@ describe('text', () => {
           type: 'text',
           field: 'test',
           values: ['asdf'],
-        })
+        }, {})
       ).to.be.true
     })
-    it('should detect missing value', () => {
+    it('should detect if values is empty', () => {
       expect(
         !!text.hasValue({
           type: 'text',
           field: 'test',
           values: [],
-        })
+        }, {})
       ).to.be.false
     })
-    it('should detect missing value if given empty string', () => {
+    it('should detect if values only contains an empty string', () => {
       expect(
         !!text.hasValue({
           type: 'text',
           field: 'test',
           values: [''],
-        })
+        }, {})
+      ).to.be.false
+    })
+    it('should detect if value is the empty string', () => {
+      expect(
+        !!text.hasValue({
+          type: 'text',
+          field: 'test',
+          value: '',
+        }, {})
       ).to.be.false
     })
   }),


### PR DESCRIPTION
Fix `hasValue` for `text` type.

Related to https://github.com/smartprocure/bid-search/issues/3779