### PR TITLE
Fix README elasticsearch->MongoDB typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MongoDB client.
 
 | Option      | Type       | Description                                      | Required |
 | ------      | ----       | -----------                                      | -------- |
-| `getClient` | `function` | Returns an instantiated elasticsearch client     | x        |
+| `getClient` | `function` | Returns an instantiated MongoDB client           | x        |
 | `types`     | `object`   | Contexture node types, like all other providers  |          |
 
 ### Schemas


### PR DESCRIPTION
This PR fixes a typo that has "elasticsearch" instead of the expected "MongoDB".