### PR TITLE
Countless results node improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 0.11.0
 * Results example type: Add `hasMore` flag to context if `skipCount` is true and the query has results beyond the current page
-* Results example type: Calculate `totalRecords` from `endRecord` if `skipCount` is true
 
 # 0.10.1
 * [DateHistogram] Fix key timestamp bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.0
+* Results example type: Add `hasMore` flag to context if `skipCount` is true and the query has results beyond the current page
+* Results example type: Calculate `totalRecords` from `endRecord` if `skipCount` is true
+
 # 0.10.1
 * [DateHistogram] Fix key timestamp bug
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.1
+* Fix typo in README
+* Fix accidental NPM publish in 0.11.0
+
 # 0.11.0
 * Results example type: Add `hasMore` flag to context if `skipCount` is true and the query has results beyond the current page
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MongoDB client.
 
 | Option      | Type       | Description                                      | Required |
 | ------      | ----       | -----------                                      | -------- |
-| `getClient` | `function` | Returns an instantiated elasticsearch client     | x        |
+| `getClient` | `function` | Returns an instantiated MongoDB client           | x        |
 | `types`     | `object`   | Contexture node types, like all other providers  |          |
 
 ### Schemas

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -104,10 +104,15 @@ let defaults = _.defaults({
 
 let getResponse = (node, results, count) => {
   let startRecord = getStartRecord(node)
+  let endRecord = startRecord + _.min([results.length, node.pageSize])
   return {
-    totalRecords: _.get('0.count', count),
+    totalRecords: _.max([
+      _.get('context.response.totalRecords', node),
+      count,
+      endRecord,
+    ]),
     startRecord: startRecord + 1,
-    endRecord: startRecord + _.min([results.length, node.pageSize]),
+    endRecord,
     ...(node.skipCount && { hasMore: results.length > node.pageSize }),
     results: _.take(node.pageSize, results),
   }
@@ -123,7 +128,7 @@ let result = async (node, search, schema, { getSchema }) => {
     !node.skipCount && search(countQuery),
   ])
 
-  return { response: getResponse(node, results, count) }
+  return { response: getResponse(node, results, _.get('0.count', count)) }
 }
 
 // NOTE: pageSize of 0 will return all records

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -104,12 +104,10 @@ let defaults = _.defaults({
 
 let getResponse = (node, results, count) => {
   let startRecord = getStartRecord(node)
-  let endRecord = startRecord + _.min([results.length, node.pageSize])
   return {
-    totalRecords:
-      count || _.max([_.get('context.response.totalRecords', node), endRecord]),
+    totalRecords: count,
     startRecord: startRecord + 1,
-    endRecord,
+    endRecord: startRecord + _.min([results.length, node.pageSize]),
     ...(node.skipCount && { hasMore: results.length > node.pageSize }),
     results: _.take(node.pageSize, results),
   }

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -106,11 +106,8 @@ let getResponse = (node, results, count) => {
   let startRecord = getStartRecord(node)
   let endRecord = startRecord + _.min([results.length, node.pageSize])
   return {
-    totalRecords: _.max([
-      _.get('context.response.totalRecords', node),
-      count,
-      endRecord,
-    ]),
+    totalRecords:
+      count || _.max([_.get('context.response.totalRecords', node), endRecord]),
     startRecord: startRecord + 1,
     endRecord,
     ...(node.skipCount && { hasMore: results.length > node.pageSize }),

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -5,6 +5,7 @@ let {
   convertPopulate,
   getResultsQuery,
   getStartRecord,
+  getResponse,
   projectFromInclude,
 } = require('../../src/example-types/results')
 
@@ -219,6 +220,17 @@ describe('results', () => {
         'bar.baz': 1,
         foo: 1,
       })
+    })
+  })
+  describe('getResponse', () => {
+    let node = defaults({ key: 'results', type: 'results', pageSize: 4 })
+    it('should only set hasMore if count is skipped', async () => {
+      expect(getResponse(node, [1, 2, 3, 4, 5]).hasMore).to.equal(undefined)
+    })
+    it('should set hasMore if there are extra results', async () => {
+      expect(
+        getResponse({ ...node, skipCount: true }, [1, 2, 3, 4, 5]).hasMore
+      ).to.equal(true)
     })
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -225,12 +225,15 @@ describe('results', () => {
   describe('getResponse', () => {
     let node = defaults({ key: 'results', type: 'results', pageSize: 4 })
     it('should only set hasMore if count is skipped', async () => {
-      expect(getResponse(node, [1, 2, 3, 4, 5]).hasMore).to.equal(undefined)
+      console.log(getResponse(node, [1, 2, 3, 4, 5]))
+      expect(getResponse(node, [1, 2, 3, 4, 5])).to.equal(undefined)
     })
     it('should set hasMore if there are extra results', async () => {
+      console.log(getResponse(node, [1, 2, 3, 4, 5]))
       expect(
         getResponse({ ...node, skipCount: true }, [1, 2, 3, 4, 5]).hasMore
       ).to.equal(true)
     })
+    it('should not set endRecord ')
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -1,3 +1,4 @@
+let F = require('futil')
 let { expect } = require('chai')
 let {
   defaults,
@@ -196,14 +197,19 @@ describe('results', () => {
       ])
     })
     it('should not have $sort stage if sortField is missing', () => {
-      let node = defaults({
-        key: 'results',
-        type: 'results',
-      })
+      let node = defaults({ key: 'results', type: 'results' })
       expect(getResultsQuery(node, getSchema, 0)).to.deep.equal([
         { $skip: 0 },
         { $limit: 10 },
       ])
+    })
+    it('should fetch an extra item if skipCount is true', () => {
+      let node = defaults({ key: 'results', type: 'results', pageSize: 10 })
+      let query = getResultsQuery(node, getSchema, 0)
+      expect(F.findApply('$limit', query)).to.equal(10)
+      let skipCountNode = { ...node, skipCount: true }
+      let skipCountQuery = getResultsQuery(skipCountNode, getSchema, 0)
+      expect(F.findApply('$limit', skipCountQuery)).to.equal(11)
     })
   })
   describe('projectFromInclude', () => {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -224,16 +224,22 @@ describe('results', () => {
   })
   describe('getResponse', () => {
     let node = defaults({ key: 'results', type: 'results', pageSize: 4 })
+    let results = [1, 2, 3, 4, 5]
     it('should only set hasMore if count is skipped', async () => {
-      console.log(getResponse(node, [1, 2, 3, 4, 5]))
-      expect(getResponse(node, [1, 2, 3, 4, 5])).to.equal(undefined)
+      expect(getResponse(node, results).hasMore).to.equal(undefined)
     })
     it('should set hasMore if there are extra results', async () => {
-      console.log(getResponse(node, [1, 2, 3, 4, 5]))
       expect(
-        getResponse({ ...node, skipCount: true }, [1, 2, 3, 4, 5]).hasMore
+        getResponse({ ...node, skipCount: true }, results).hasMore
       ).to.equal(true)
     })
-    it('should not set endRecord ')
+    it('should set startRecord and endRecord based on the page', () => {
+      let { startRecord, endRecord } = getResponse(
+        { ...node, page: 2 },
+        results
+      )
+      expect(startRecord).to.equal(5)
+      expect(endRecord).to.equal(8)
+    })
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -241,5 +241,20 @@ describe('results', () => {
       expect(startRecord).to.equal(5)
       expect(endRecord).to.equal(8)
     })
+    let nodeWithTotal = {
+      ...node,
+      context: { response: { totalRecords: 7 } },
+    }
+    it('should set totalRecords based on the count (if it exists)', () => {
+      expect(getResponse(nodeWithTotal, results, 6).totalRecords).to.equal(6)
+    })
+    it('should preserve totalRecords on the node', () => {
+      expect(getResponse(nodeWithTotal, results).totalRecords).to.equal(7)
+    })
+    it('should set totalRecords based on endRecord if count is not available', () => {
+      expect(
+        getResponse({ ...nodeWithTotal, page: 2 }, results).totalRecords
+      ).to.equal(8)
+    })
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -241,20 +241,9 @@ describe('results', () => {
       expect(startRecord).to.equal(5)
       expect(endRecord).to.equal(8)
     })
-    let nodeWithTotal = {
-      ...node,
-      context: { response: { totalRecords: 7 } },
-    }
     it('should set totalRecords based on the count (if it exists)', () => {
-      expect(getResponse(nodeWithTotal, results, 6).totalRecords).to.equal(6)
-    })
-    it('should preserve totalRecords on the node', () => {
-      expect(getResponse(nodeWithTotal, results).totalRecords).to.equal(7)
-    })
-    it('should set totalRecords based on endRecord if count is not available', () => {
-      expect(
-        getResponse({ ...nodeWithTotal, page: 2 }, results).totalRecords
-      ).to.equal(8)
+      expect(getResponse(node, results, 9001).totalRecords).to.equal(9001)
+      expect(getResponse(node, results).totalRecords).to.equal(undefined)
     })
   })
 })


### PR DESCRIPTION
This is definitely a pull request from a feature branch, yep

Contains a discrete number of improvements for results nodes without counts (now that we have `skipCount`):
- Add a `hasMore` flag to `context.response`, which is determined by trying to fetch one more result than the page size dictates and seeing if we got anything
- ~~If an actual record count is not available, results nodes will now populate `context.response.totalRecords` with an approximation of the total using the highest-numbered `endRecord` seen so far (also needs an update in contexture-client to force `totalRecords` back to zero when the node is refreshed by someone else)~~ this was dumb
- Split out the code to generate the response object into a `getResponse` function (mostly for testing)