### PR TITLE
Schema Views (aka schema defined aggregations)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+let _ = require('lodash/fp')
 let Promise = require('bluebird')
 
 // Basic function to encapsulate everything needed to run a request - tiny wrapper over raw mongo syntax
@@ -18,12 +19,13 @@ let MongoProvider = config => ({
       request: {
         // criteria: filters,
         collection: schema.mongo.collection,
-        aggs: [
+        aggs: _.compact([
+          ...schema.mongo.aggs,
           {
             $match: filters || {},
           },
           ...aggs,
-        ],
+        ]),
       },
     }
 


### PR DESCRIPTION
This would add support for arbitrary `aggs` defined as part of schemas. It's effectively the same as creating a non-materialized view, but we've discussed this enough times that it makes sense to have this PR open as a discussion point.

You'd use it like this, which shows an example of performing a lookup before running any other filters:

```js
let schema = {
  name: 'joinedRequests',
  mongo: {
    collection: 'quoteRequest',
    aggs: [{ $lookup: { from: 'organization', /*...*/ } }],
  },
}
```

An alternative to this might be explicit support for `$lookup` only, because we can optimize better than Mongo could natively. The idea would be to only run the lookup only if needed and as late as possible - up front if it's needed for filters, after the filters if it's only needed for results, and not at all if the results don't need it, either. We'd likely add an API for node types to specify their lookup dependencies so we don't resort to something naive like a regex/string includes on a stringified Mongo blob 😂 