### PR TITLE
Fix: missing select values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.17.1
+* Fix the missing select values bug for facet type
+
 # 0.17.0
 * Add more rolling date types.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -139,7 +139,7 @@ module.exports = {
 
     let missedValues = _.difference(
       values,
-      _.map(x => _.toString(x.name), results.options)
+      _.map(({name}) => _.toString(name), results.options)
     )
 
     let getSelectValues = node =>
@@ -149,7 +149,7 @@ module.exports = {
       $match: { _id: { $in: getSelectValues(node) } },
     })
 
-    if (!_.isEmpty(values) && !_.isEmpty(missedValues)) {
+    if (!_.isEmpty(missedValues)) {
       //create a values hash map for filter noValuesOptions
       let getValuesIndex = _.reduce(
         (acc, value) => {
@@ -202,7 +202,7 @@ module.exports = {
           }),
         searchValues
       )
-      results.options = noValuesOptions.concat(valuesOptions)
+      results.options = _.concat(valuesOptions,noValuesOptions)
     }
 
     return results

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -136,7 +136,7 @@ module.exports = {
         options
       ),
     }))
-
+    // results.options.name is ObjectId which need to stringify to get the correct missedValues
     let missedValues = _.difference(
       values,
       _.map(({name}) => _.toString(name), results.options)

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -137,10 +137,12 @@ module.exports = {
       ),
     }))
 
+
     let missedValues = _.difference(
       values,
       _.map(x => _.toString(x.name), results.options)
     )
+
     let getSelectValues = node =>
       node.isMongoId ? _.map(ObjectID, values) : values
 
@@ -164,7 +166,7 @@ module.exports = {
         results.options
       )
       let dropSize = noValuesOptions.length + values.length - node.size
-      if (dropSize > 0) _.drop(dropSize, noValuesOptions)
+      if (dropSize > 0) noValuesOptions=_.drop(dropSize, noValuesOptions)
 
       let searchValues = await search(
         _.compact([

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -58,10 +58,7 @@ let mapKeywordFilters = node =>
   _.flow(getSearchableKeysList, list => ({
     $match: setMatchOperators(list, node),
   }))(node)
-let mapKeywordFilters2 = node =>
-  _.flow(getSearchableKeysList, list => ({
-    $match: setMatchOperators(list, node),
-  }))(node)
+
 
 let facetValueLabel = (node, label) => {
   if (!node.label) {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -150,6 +150,7 @@ module.exports = {
     })
 
     if (!_.isEmpty(values) && !_.isEmpty(missedValues)) {
+      //create a values hash map for filter noValuesOptions
       let getValuesIndex = _.reduce(
         (acc, value) => {
           acc[value] = true

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -137,8 +137,9 @@ module.exports = {
       ),
     }))
     // results.options.name is ObjectId which need to stringify to get the correct missedValues
+    // stringify values to avoid the bug when values are numeric values
     let missedValues = _.difference(
-      values,
+      _.map(_.toString,values),
       _.map(({ name }) => _.toString(name), results.options)
     )
 

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -140,7 +140,6 @@ module.exports = {
       ),
     }))
 
-    // results.options.name is ObjectId which need to stringify to get the correct missedValues
     let missedValues = _.difference(
       values,
       _.map(

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -141,7 +141,6 @@ module.exports = {
     }))
 
     // results.options.name is ObjectId which need to stringify to get the correct missedValues
-    // can not stringify values to avoid the bug when values are numeric values
     let missedValues = _.difference(
        values,
       _.map(({ name }) => node.isMongoId ?_.toString(name):name, results.options)

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -172,7 +172,7 @@ module.exports = {
       let stillMissingQueryFilter =  {[node.field]: { $in: getMissedValues(node,stillMissingValues) } }
       let stillMissingArgs =  [ { $group: { _id: `$${node.field}`} },...lookupLabel(node), _.get('label.fields', node) && projectStageFromLabelFields(node),]
       let stillmissingResult = []
-      if(stillMissingValues){
+      if(!_.isEmpty(stillMissingValues)){
         //use config to run runSearch(options, node, schema, filters, aggs)  function
         stillmissingResult = await config.getProvider(node).runSearch(config.options, node, config.getSchema(node.schema), stillMissingQueryFilter, stillMissingArgs)
       }

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -162,6 +162,7 @@ module.exports = {
           ...sortAndLimitIfNotSearching(node.optionsFilter, node.size),
           ...lookupLabel(node),
           _.get('label.fields', node) && projectStageFromLabelFields(node),
+          mapKeywordFilters(node),
         ])
       )
       let stillMissingValues = _.difference(

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -141,10 +141,10 @@ module.exports = {
     }))
 
     // results.options.name is ObjectId which need to stringify to get the correct missedValues
-    // stringify values to avoid the bug when values are numeric values
+    // can not stringify values to avoid the bug when values are numeric values
     let missedValues = _.difference(
-      _.map(_.toString, values),
-      _.map(({ name }) => _.toString(name), results.options)
+       values,
+      _.map(({ name }) => node.isMongoId ?_.toString(name):name, results.options)
     )
 
     let getMissedValues = (node, missedValues) =>
@@ -165,8 +165,9 @@ module.exports = {
           mapKeywordFilters(node),
         ])
       )
+      //stringify missedValues to avoid the bug when values are numeric values
       let stillMissingValues = _.difference(
-        missedValues,
+        _.map(_.toString, missedValues),
         _.map(x => _.toString(x[`${node.field}`]), searchMissedResult)
       )
       let stillMissingQueryFilter = {

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -465,7 +465,7 @@ describe('facet', () => {
       it('when missing checked values are expected', async () => {
         node.label.collection = Data
         // node.values is selected values
-        // when we use [4], we could expect missing values because the first search will pick up the top 2 ids instead of 4 (the last item in the array)
+        // when we use [4], we could expect missing values because the first search will pick up the top 2 ids instead of value 4 (the last item from the array)
         node.values = [4]
         let result = await facet.result(node, agg => mingo.aggregate(Data, agg))
         let ids = _.map(({ name }) => _.toString(name), result.options)

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -465,11 +465,8 @@ describe('facet', () => {
         size: 2,
       }
       it('when missing checked values are expected', async() => {
-
         node.label.collection= Data
-
         node.values = [4]
-
         let result = await facet.result(node, agg =>
           mingo.aggregate(Data, agg)
         )
@@ -495,12 +492,10 @@ describe('facet', () => {
         node.isMongoId= true
         node.label.collection= collection
         node.values = ['5ce30b403aa154002d01b9ed']
-
         let result = await facet.result(node, agg =>
           mingo.aggregate(collection, agg)
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
-
         expect(result.options.length).to.equal(2)
         expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
       })
@@ -512,17 +507,13 @@ describe('facet', () => {
         node.isMongoId= true
         node.label.collection= collection
         node.values = ['5e9dbd76e991760021124966']
-
         let result = await facet.result(node, agg =>
           mingo.aggregate(collection, agg)
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
-
         expect(result.options.length).to.equal(2)
         expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
       })
-
-
     })
 
   })

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -436,7 +436,7 @@ describe('facet', () => {
       })
     })
 
-    describe('should always include checked values', () => {
+    describe('should always include checked values in result', () => {
 
 
       let Data = [
@@ -464,9 +464,9 @@ describe('facet', () => {
         optionsFilter: '',
         size: 2,
       }
-      it('when there are missed values', async() => {
+      it('when missing checked values are expected', async() => {
 
-        node.label.collection= Data,
+        node.label.collection= Data
 
         node.values = [4]
 
@@ -477,8 +477,8 @@ describe('facet', () => {
         expect(result.options.length).to.equal(2)
         expect(_.includes('4', ids)).to.be.true
       })
-      it('when there is no missed value', async() => {
-        node.label.collection= Data,
+      it('when missing checked values are not expected', async() => {
+        node.label.collection= Data
         node.values = [1]
         let result = await facet.result(node, agg =>
           mingo.aggregate(Data, agg)
@@ -487,13 +487,13 @@ describe('facet', () => {
         expect(result.options.length).to.equal(2)
         expect(_.includes('1', ids)).to.be.true
       })
-      it('when there are missed values and isMongoId: true', async() => {
+      it('when missing checked values are expected and isMongoId is true', async() => {
         let collection = _.map(
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
           mongoIdData
         )
         node.isMongoId= true
-        node.label.collection= collection,
+        node.label.collection= collection
         node.values = ['5ce30b403aa154002d01b9ed']
 
         let result = await facet.result(node, agg =>
@@ -504,13 +504,13 @@ describe('facet', () => {
         expect(result.options.length).to.equal(2)
         expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
       })
-      it('when there is no missed value and isMongoId: true', async() => {
+      it('when missing checked values are not expected and  isMongoId is true', async() => {
         let collection = _.map(
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
           mongoIdData
         )
         node.isMongoId= true
-        node.label.collection= collection,
+        node.label.collection= collection
         node.values = ['5e9dbd76e991760021124966']
 
         let result = await facet.result(node, agg =>

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -435,7 +435,7 @@ describe('facet', () => {
         ],
       })
     })
-    it.only('should return correct search result when checked value missing', async () => {
+    it('should return correct search result when checked value missing', async () => {
 
       let data = [
         { _id: '5e9dbd76e991760021124966', name: 'Automation' },
@@ -458,16 +458,17 @@ describe('facet', () => {
         { _id: '5d1ca49436e1d20038f8c84f', name: 'Customer Experience' },
         { _id: '5ce30b403aa154002d01b9ed', name: 'Government Division' },
       ]
+      // eslint-disable-next-line
       let collection = _.map(x=>{return {_id:ObjectID(x['_id']),name:x.name}},data)
 
       //5d1ca49436e1d20038f8c84f and 5ce30b403aa154002d01b9ed are the values from buttom of the records they are missing values
-      node ={
+      let  node ={
         key: 'id',
         field: '_id',
         type: 'facet',
         isMongoId: true,
         label: {
-          collection: collection,
+          collection,
           foreignField: '_id',
           fields: [ 'name' ]
         },

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -435,42 +435,129 @@ describe('facet', () => {
         ],
       })
     })
-    it('should sort options by whether their values are selected', async () => {
-      let data = [
+
+
+    describe('should always include checked values', () => {
+      let Data = [
+        { _id: 1, name: '1' },
+        { _id: 2, name: '2' },
+        { _id: 3, name: '3' },
+        { _id: 4, name: '4' },
+      ]
+      let mongoIdData = [
         { _id: '5e9dbd76e991760021124966', name: 'Automation' },
         { _id: '5cde2658dc766b0030c67dae', name: 'Fowlkes (MO)' },
         { _id: '5d1ca49436e1d20038f8c84f', name: 'Customer Experience' },
         { _id: '5ce30b403aa154002d01b9ed', name: 'Government Division' },
       ]
-      let collection = _.map(
-        ({ _id, name }) => ({ _id: ObjectID(_id), name }),
-        data
-      )
 
-      //5ce30b403aa154002d01b9ed is the missing value
-      let node = {
-        key: 'id',
-        field: '_id',
-        type: 'facet',
-        isMongoId: true,
-        label: {
-          collection,
-          foreignField: '_id',
-          fields: ['name'],
-        },
-        values: ['5ce30b403aa154002d01b9ed'],
-        mode: 'include',
-        optionsFilter: '',
-        size: 2,
-      }
+      it('when there are missed values', async() => {
+        let collection= Data
+        let node = {
+          key: 'id',
+          field: '_id',
+          type: 'facet',
+          label: {
+            collection,
+            foreignField: '_id',
+            fields: ['name'],
+          },
+          values: [4],
+          mode: 'include',
+          optionsFilter: '',
+          size: 2,
+        }
+        let result = await facet.result(node, agg =>
+          mingo.aggregate(collection, agg)
+        )
+        let ids = _.map(({ name }) => _.toString(name), result.options)
+        expect(result.options.length).to.equal(2)
+        expect(_.includes('4', ids)).to.be.true
+      })
+      it('when there is no missed value', async() => {
+        let collection= Data
+        let node = {
+          key: 'id',
+          field: '_id',
+          type: 'facet',
+          label: {
+            collection,
+            foreignField: '_id',
+            fields: ['name'],
+          },
+          values: [1],
+          mode: 'include',
+          optionsFilter: '',
+          size: 2,
+        }
+        let result = await facet.result(node, agg =>
+          mingo.aggregate(collection, agg)
+        )
+        let ids = _.map(({ name }) => _.toString(name), result.options)
+        expect(result.options.length).to.equal(2)
+        expect(_.includes('1', ids)).to.be.true
+      })
+      it('when there are missed values and isMongoId: true', async() => {
+        let collection = _.map(
+          ({ _id, name }) => ({ _id: ObjectID(_id), name }),
+          mongoIdData
+        )
+        let node = {
+          key: 'id',
+          field: '_id',
+          type: 'facet',
+          isMongoId: true,
+          label: {
+            collection,
+            foreignField: '_id',
+            fields: ['name'],
+          },
+          values: ['5ce30b403aa154002d01b9ed'],
+          mode: 'include',
+          optionsFilter: '',
+          size: 2,
+        }
 
-      let result = await facet.result(node, agg =>
-        mingo.aggregate(collection, agg)
-      )
-      let ids = _.map(({ name }) => _.toString(name), result.options)
+        let result = await facet.result(node, agg =>
+          mingo.aggregate(collection, agg)
+        )
+        let ids = _.map(({ name }) => _.toString(name), result.options)
 
-      expect(result.options.length).to.equal(2)
-      expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
+        expect(result.options.length).to.equal(2)
+        expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
+      })
+      it('when there is no missed value and isMongoId: true', async() => {
+        let collection = _.map(
+          ({ _id, name }) => ({ _id: ObjectID(_id), name }),
+          mongoIdData
+        )
+        let node = {
+          key: 'id',
+          field: '_id',
+          type: 'facet',
+          isMongoId: true,
+          label: {
+            collection,
+            foreignField: '_id',
+            fields: ['name'],
+          },
+          values: ['5e9dbd76e991760021124966'],
+          mode: 'include',
+          optionsFilter: '',
+          size: 2,
+        }
+
+        let result = await facet.result(node, agg =>
+          mingo.aggregate(collection, agg)
+        )
+        let ids = _.map(({ name }) => _.toString(name), result.options)
+
+        expect(result.options.length).to.equal(2)
+        expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
+      })
+
+
     })
+
   })
 })

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -435,30 +435,14 @@ describe('facet', () => {
         ],
       })
     })
-    it('should return correct search result when checked value missing', async () => {
+    it('should sort options by whether their values are selected', async () => {
       let data = [
         { _id: '5e9dbd76e991760021124966', name: 'Automation' },
         { _id: '5cde2658dc766b0030c67dae', name: 'Fowlkes (MO)' },
-        { _id: '5ebef03a06acda0021797bfd', name: 'Automation' },
-        { _id: '5cde259edc766b0030c67d9e', name: 'Lombardi (AR)' },
-        { _id: '5ea6e54479a8c60021156015', name: 'Automation' },
-        { _id: '5cde25bedc766b0030c67da1', name: 'Whipple' },
-        { _id: '5ee1378770824e00213ffe07', name: 'Katalon Test' },
-        { _id: '5ea1e2ccc2ce7b0022c2655a', name: 'Automation' },
-        { _id: '5ebabd429a42630021a86a35', name: 'Finance' },
-        { _id: '5e5e9b2bdda1c5002bdb9e9f', name: 'Silver Cooper' },
-        { _id: '5d52fea84e01ee003782da3e', name: 'Andrea Restrepo ' },
-        { _id: '5f0f2bc8c66f260021280d37', name: 'Automation' },
-        { _id: '5ce3f7a1c5b085002cb2a330', name: 'Stephen Mailloux' },
-        { _id: '5f208018ddcb610021a43d82', name: 'Automation' },
-        { _id: '5ea86df23aab7500215be93a', name: 'Automation' },
-        { _id: '5cde208b87eff60030d9c0b1', name: 'Morris (RJ)' },
-        { _id: '5f032194fefab4002119ce92', name: 'Katalon Test' },
         { _id: '5d1ca49436e1d20038f8c84f', name: 'Customer Experience' },
         { _id: '5ce30b403aa154002d01b9ed', name: 'Government Division' },
       ]
-      // eslint-disable-next-line
-      let collection = _.map(x=>{return {_id:ObjectID(x['_id']),name:x.name}},data)
+      let collection = _.map( ({ _id, name })=>({ _id: ObjectID(_id), name }),data)
 
       //5d1ca49436e1d20038f8c84f and 5ce30b403aa154002d01b9ed are the values from buttom of the records they are missing values
       let  node ={
@@ -472,26 +456,21 @@ describe('facet', () => {
           fields: ['name'],
         },
         values: [
-          '5d1ca49436e1d20038f8c84f',
           '5ce30b403aa154002d01b9ed',
-          '5e9dbd76e991760021124966',
-          '5cde2658dc766b0030c67dae',
         ],
         mode: 'include',
         optionsFilter: '',
-        size: 10,
+        size: 2,
       }
 
       let result = await facet.result(node, agg =>
         mingo.aggregate(collection, agg)
       )
-      let ids = _.map(x => _.toString(x.name), result.options)
+      let ids = _.map(({name}) => _.toString(name), result.options)
 
-      expect(result.options.length).to.equal(10)
-      expect(_.includes('5d1ca49436e1d20038f8c84f', ids)).to.be.true
+      expect(result.options.length).to.equal(2)
       expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
-      expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
-      expect(_.includes('5cde2658dc766b0030c67dae', ids)).to.be.true
+
     })
   })
 })

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -438,6 +438,8 @@ describe('facet', () => {
 
 
     describe('should always include checked values', () => {
+
+
       let Data = [
         { _id: 1, name: '1' },
         { _id: 2, name: '2' },
@@ -450,23 +452,23 @@ describe('facet', () => {
         { _id: '5d1ca49436e1d20038f8c84f', name: 'Customer Experience' },
         { _id: '5ce30b403aa154002d01b9ed', name: 'Government Division' },
       ]
-
+     let node = {
+        key: 'id',
+        field: '_id',
+        type: 'facet',
+        mode: 'include',
+        optionsFilter: '',
+        size: 2,
+      }
       it('when there are missed values', async() => {
         let collection= Data
-        let node = {
-          key: 'id',
-          field: '_id',
-          type: 'facet',
-          label: {
-            collection,
+        node.label={
+          collection,
             foreignField: '_id',
             fields: ['name'],
-          },
-          values: [4],
-          mode: 'include',
-          optionsFilter: '',
-          size: 2,
         }
+        node.values = [4]
+
         let result = await facet.result(node, agg =>
           mingo.aggregate(collection, agg)
         )
@@ -476,20 +478,12 @@ describe('facet', () => {
       })
       it('when there is no missed value', async() => {
         let collection= Data
-        let node = {
-          key: 'id',
-          field: '_id',
-          type: 'facet',
-          label: {
-            collection,
-            foreignField: '_id',
-            fields: ['name'],
-          },
-          values: [1],
-          mode: 'include',
-          optionsFilter: '',
-          size: 2,
+        node.label={
+          collection,
+          foreignField: '_id',
+          fields: ['name'],
         }
+        node.values = [1]
         let result = await facet.result(node, agg =>
           mingo.aggregate(collection, agg)
         )
@@ -502,21 +496,13 @@ describe('facet', () => {
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
           mongoIdData
         )
-        let node = {
-          key: 'id',
-          field: '_id',
-          type: 'facet',
-          isMongoId: true,
-          label: {
-            collection,
-            foreignField: '_id',
-            fields: ['name'],
-          },
-          values: ['5ce30b403aa154002d01b9ed'],
-          mode: 'include',
-          optionsFilter: '',
-          size: 2,
+        node.isMongoId= true
+        node.label={
+          collection,
+          foreignField: '_id',
+          fields: ['name'],
         }
+        node.values = ['5ce30b403aa154002d01b9ed']
 
         let result = await facet.result(node, agg =>
           mingo.aggregate(collection, agg)
@@ -531,21 +517,13 @@ describe('facet', () => {
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
           mongoIdData
         )
-        let node = {
-          key: 'id',
-          field: '_id',
-          type: 'facet',
-          isMongoId: true,
-          label: {
-            collection,
-            foreignField: '_id',
-            fields: ['name'],
-          },
-          values: ['5e9dbd76e991760021124966'],
-          mode: 'include',
-          optionsFilter: '',
-          size: 2,
+        node.isMongoId= true
+        node.label={
+          collection,
+          foreignField: '_id',
+          fields: ['name'],
         }
+        node.values = ['5e9dbd76e991760021124966']
 
         let result = await facet.result(node, agg =>
           mingo.aggregate(collection, agg)

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -455,36 +455,33 @@ describe('facet', () => {
         key: 'id',
         field: '_id',
         type: 'facet',
+       label:{
+         collection:null,
+         foreignField: '_id',
+         fields: ['name'],
+       },
         mode: 'include',
         optionsFilter: '',
         size: 2,
       }
       it('when there are missed values', async() => {
-        let collection= Data
-        node.label={
-          collection,
-            foreignField: '_id',
-            fields: ['name'],
-        }
+
+        node.label.collection= Data,
+
         node.values = [4]
 
         let result = await facet.result(node, agg =>
-          mingo.aggregate(collection, agg)
+          mingo.aggregate(Data, agg)
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(result.options.length).to.equal(2)
         expect(_.includes('4', ids)).to.be.true
       })
       it('when there is no missed value', async() => {
-        let collection= Data
-        node.label={
-          collection,
-          foreignField: '_id',
-          fields: ['name'],
-        }
+        node.label.collection= Data,
         node.values = [1]
         let result = await facet.result(node, agg =>
-          mingo.aggregate(collection, agg)
+          mingo.aggregate(Data, agg)
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(result.options.length).to.equal(2)
@@ -496,11 +493,7 @@ describe('facet', () => {
           mongoIdData
         )
         node.isMongoId= true
-        node.label={
-          collection,
-          foreignField: '_id',
-          fields: ['name'],
-        }
+        node.label.collection= collection,
         node.values = ['5ce30b403aa154002d01b9ed']
 
         let result = await facet.result(node, agg =>
@@ -517,11 +510,7 @@ describe('facet', () => {
           mongoIdData
         )
         node.isMongoId= true
-        node.label={
-          collection,
-          foreignField: '_id',
-          fields: ['name'],
-        }
+        node.label.collection= collection,
         node.values = ['5e9dbd76e991760021124966']
 
         let result = await facet.result(node, agg =>

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -1,6 +1,7 @@
 let { expect } = require('chai')
 let _ = require('lodash/fp')
 let facet = require('../../src/example-types/facet')
+let { ObjectID } = require('mongodb')
 let mingo = require('mingo')
 
 describe('facet', () => {
@@ -433,6 +434,64 @@ describe('facet', () => {
           { name: 'secondField', count: 1 },
         ],
       })
+    })
+    it.only('should return correct search result when checked value missing', async () => {
+
+      let data = [
+        { _id: '5e9dbd76e991760021124966', name: 'Automation' },
+        { _id: '5cde2658dc766b0030c67dae', name: 'Fowlkes (MO)' },
+        { _id: '5ebef03a06acda0021797bfd', name: 'Automation' },
+        { _id: '5cde259edc766b0030c67d9e', name: 'Lombardi (AR)' },
+        { _id: '5ea6e54479a8c60021156015', name: 'Automation' },
+        { _id: '5cde25bedc766b0030c67da1', name: 'Whipple' },
+        { _id: '5ee1378770824e00213ffe07', name: 'Katalon Test' },
+        { _id: '5ea1e2ccc2ce7b0022c2655a', name: 'Automation' },
+        { _id: '5ebabd429a42630021a86a35', name: 'Finance' },
+        { _id: '5e5e9b2bdda1c5002bdb9e9f', name: 'Silver Cooper' },
+        { _id: '5d52fea84e01ee003782da3e', name: 'Andrea Restrepo ' },
+        { _id: '5f0f2bc8c66f260021280d37', name: 'Automation' },
+        { _id: '5ce3f7a1c5b085002cb2a330', name: 'Stephen Mailloux' },
+        { _id: '5f208018ddcb610021a43d82', name: 'Automation' },
+        { _id: '5ea86df23aab7500215be93a', name: 'Automation' },
+        { _id: '5cde208b87eff60030d9c0b1', name: 'Morris (RJ)' },
+        { _id: '5f032194fefab4002119ce92', name: 'Katalon Test' },
+        { _id: '5d1ca49436e1d20038f8c84f', name: 'Customer Experience' },
+        { _id: '5ce30b403aa154002d01b9ed', name: 'Government Division' },
+      ]
+      let collection = _.map(x=>{return {_id:ObjectID(x['_id']),name:x.name}},data)
+
+      //5d1ca49436e1d20038f8c84f and 5ce30b403aa154002d01b9ed are the values from buttom of the records they are missing values
+      node ={
+        key: 'id',
+        field: '_id',
+        type: 'facet',
+        isMongoId: true,
+        label: {
+          collection: collection,
+          foreignField: '_id',
+          fields: [ 'name' ]
+        },
+        values: [
+          '5d1ca49436e1d20038f8c84f',
+          '5ce30b403aa154002d01b9ed',
+          '5e9dbd76e991760021124966',
+          '5cde2658dc766b0030c67dae'
+        ],
+        mode: 'include',
+        optionsFilter: '',
+        size: 10,
+      }
+
+      let result = await facet.result(node, agg =>
+        mingo.aggregate(collection, agg)
+      )
+      let ids = (_.map((x)=>_.toString(x.name),result.options))
+
+      expect(result.options.length).to.equal(10)
+      expect(_.includes('5d1ca49436e1d20038f8c84f',ids)).to.be.true
+      expect(_.includes('5ce30b403aa154002d01b9ed',ids)).to.be.true
+      expect(_.includes('5e9dbd76e991760021124966',ids)).to.be.true
+      expect(_.includes('5cde2658dc766b0030c67dae',ids)).to.be.true
     })
   })
 })

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -465,6 +465,7 @@ describe('facet', () => {
       it('when missing checked values are expected', async () => {
         node.label.collection = Data
         // node.values is selected values
+        // when we use [4], we could expect missing values because the first search will pick up the top 2 ids instead of 4 (the last item in the array)
         node.values = [4]
         let result = await facet.result(node, agg => mingo.aggregate(Data, agg))
         let ids = _.map(({ name }) => _.toString(name), result.options)

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -464,9 +464,8 @@ describe('facet', () => {
       }
       it('when missing checked values are expected', async () => {
         node.label.collection = Data
-
+        // node.values is selected values
         node.values = [4]
-
         let result = await facet.result(node, agg => mingo.aggregate(Data, agg))
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(result.options.length).to.equal(2)

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -3,7 +3,7 @@ let _ = require('lodash/fp')
 let facet = require('../../src/example-types/facet')
 let { ObjectID } = require('mongodb')
 let mingo = require('mingo')
-
+let getSchema = collection => ({ mongo: { collection } })
 describe('facet', () => {
   describe('facet.hasValue', () => {
     it('Should allow nodes with values', () => {
@@ -462,16 +462,7 @@ describe('facet', () => {
         optionsFilter: '',
         size: 2,
       }
-      it('when missing checked values in first search are expected', async () => {
-        node.label.collection = Data
-        // node.values is selected values
-        // when we use [4], we could expect missing values in first search because the first search will pick up the top 2 ids instead of value 4 (the last item from the array)
-        node.values = [4]
-        let result = await facet.result(node, agg => mingo.aggregate(Data, agg))
-        let ids = _.map(({ name }) => _.toString(name), result.options)
-        expect(result.options.length).to.equal(2)
-        expect(_.includes('4', ids)).to.be.true
-      })
+
       it('when missing checked values in first search are not expected', async () => {
         node.label.collection = Data
         node.values = [1]
@@ -480,22 +471,7 @@ describe('facet', () => {
         expect(result.options.length).to.equal(2)
         expect(_.includes('1', ids)).to.be.true
       })
-      it('when missing checked values in first search are expected and isMongoId is true', async () => {
-        let collection = _.map(
-          ({ _id, name }) => ({ _id: ObjectID(_id), name }),
-          mongoIdData
-        )
-        node.isMongoId = true
-        node.label.collection = collection
-        node.values = ['5ce30b403aa154002d01b9ed']
 
-        let result = await facet.result(node, agg =>
-          mingo.aggregate(collection, agg)
-        )
-        let ids = _.map(({ name }) => _.toString(name), result.options)
-        expect(result.options.length).to.equal(2)
-        expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
-      })
       it('when missing checked values in first search are not expected and  isMongoId is true', async () => {
         let collection = _.map(
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
@@ -509,7 +485,6 @@ describe('facet', () => {
           mingo.aggregate(collection, agg)
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
-
         expect(result.options.length).to.equal(2)
         expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
       })

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -437,10 +437,10 @@ describe('facet', () => {
 
     describe('should always include checked values in result', () => {
       let Data = [
-        { _id: '1', name: '1' },
-        { _id: '2', name: '2' },
-        { _id: '3', name: '3' },
-        { _id: '4', name: '4' },
+        { _id: 1, name: '1' },
+        { _id: 2, name: '2' },
+        { _id: 3, name: '3' },
+        { _id: 4, name: '4' },
       ]
       let mongoIdData = [
         { _id: '5e9dbd76e991760021124966', name: 'Automation' },

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -509,26 +509,26 @@ describe('facet', () => {
         expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
       })
       it('when the first and second search result does not  contain the checked value',async()=>{
-        let config ={
+        let mockConfig ={
           getProvider:()=>({runSearch:()=>[ {  label: { name: '5' }, _id: 5 } ],
           }),
-          getSchema:()=>null
+          getSchema:()=>{}
         }
 
         node.label.collection = Data
         node.isMongoId = null
         node.values = [5]
         let result = await facet.result(node, agg =>
-          mingo.aggregate(Data, agg),null,config
+          mingo.aggregate(Data, agg), { },mockConfig
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(_.includes('5', ids)).to.be.true
       })
       it('when the first and second search result does not  contain the checked value  and  isMongoId is true',async()=>{
-        let config ={
+        let mockConfig ={
           getProvider:()=>({runSearch:()=>[ {  label: { name: 'test' }, _id: '5ce30b403aa154002d01b9dd' } ],
           }),
-          getSchema:()=>null
+          getSchema:()=>{}
         }
 
         let collection = _.map(
@@ -539,7 +539,7 @@ describe('facet', () => {
         node.label.collection = collection
         node.values = ['5ce30b403aa154002d01b9dd']
         let result = await facet.result(node, agg =>
-          mingo.aggregate(collection, agg),null,config
+          mingo.aggregate(collection, agg),{},mockConfig
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(_.includes('5ce30b403aa154002d01b9dd', ids)).to.be.true

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -508,27 +508,34 @@ describe('facet', () => {
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
       })
-      it('when the first and second search result does not  contain the checked value',async()=>{
-        let mockConfig ={
-          getProvider:()=>({runSearch:()=>[ {  label: { name: '5' }, _id: 5 } ],
+      it('when the first and second search result does not  contain the checked value', async () => {
+        let mockConfig = {
+          getProvider: () => ({
+            runSearch: () => [{ label: { name: '5' }, _id: 5 }],
           }),
-          getSchema:()=>{}
+          getSchema() {},
         }
 
         node.label.collection = Data
         node.isMongoId = null
         node.values = [5]
-        let result = await facet.result(node, agg =>
-          mingo.aggregate(Data, agg), { },mockConfig
+        let result = await facet.result(
+          node,
+          agg => mingo.aggregate(Data, agg),
+          {},
+          mockConfig
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(_.includes('5', ids)).to.be.true
       })
-      it('when the first and second search result does not  contain the checked value  and  isMongoId is true',async()=>{
-        let mockConfig ={
-          getProvider:()=>({runSearch:()=>[ {  label: { name: 'test' }, _id: '5ce30b403aa154002d01b9dd' } ],
+      it('when the first and second search result does not  contain the checked value  and  isMongoId is true', async () => {
+        let mockConfig = {
+          getProvider: () => ({
+            runSearch: () => [
+              { label: { name: 'test' }, _id: '5ce30b403aa154002d01b9dd' },
+            ],
           }),
-          getSchema:()=>{}
+          getSchema() {},
         }
 
         let collection = _.map(
@@ -538,8 +545,11 @@ describe('facet', () => {
         node.isMongoId = true
         node.label.collection = collection
         node.values = ['5ce30b403aa154002d01b9dd']
-        let result = await facet.result(node, agg =>
-          mingo.aggregate(collection, agg),{},mockConfig
+        let result = await facet.result(
+          node,
+          agg => mingo.aggregate(collection, agg),
+          {},
+          mockConfig
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(_.includes('5ce30b403aa154002d01b9dd', ids)).to.be.true

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -462,17 +462,17 @@ describe('facet', () => {
         optionsFilter: '',
         size: 2,
       }
-      it('when missing checked values are expected', async () => {
+      it('when missing checked values in first search are expected', async () => {
         node.label.collection = Data
         // node.values is selected values
-        // when we use [4], we could expect missing values because the first search will pick up the top 2 ids instead of value 4 (the last item from the array)
+        // when we use [4], we could expect missing values in first search because the first search will pick up the top 2 ids instead of value 4 (the last item from the array)
         node.values = [4]
         let result = await facet.result(node, agg => mingo.aggregate(Data, agg))
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(result.options.length).to.equal(2)
         expect(_.includes('4', ids)).to.be.true
       })
-      it('when missing checked values are not expected', async () => {
+      it('when missing checked values in first search are not expected', async () => {
         node.label.collection = Data
         node.values = [1]
         let result = await facet.result(node, agg => mingo.aggregate(Data, agg))
@@ -480,7 +480,7 @@ describe('facet', () => {
         expect(result.options.length).to.equal(2)
         expect(_.includes('1', ids)).to.be.true
       })
-      it('when missing checked values are expected and isMongoId is true', async () => {
+      it('when missing checked values in first search are expected and isMongoId is true', async () => {
         let collection = _.map(
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
           mongoIdData
@@ -496,7 +496,7 @@ describe('facet', () => {
         expect(result.options.length).to.equal(2)
         expect(_.includes('5ce30b403aa154002d01b9ed', ids)).to.be.true
       })
-      it('when missing checked values are not expected and  isMongoId is true', async () => {
+      it('when missing checked values in first search are not expected and  isMongoId is true', async () => {
         let collection = _.map(
           ({ _id, name }) => ({ _id: ObjectID(_id), name }),
           mongoIdData

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -3,7 +3,6 @@ let _ = require('lodash/fp')
 let facet = require('../../src/example-types/facet')
 let { ObjectID } = require('mongodb')
 let mingo = require('mingo')
-let getSchema = collection => ({ mongo: { collection } })
 describe('facet', () => {
   describe('facet.hasValue', () => {
     it('Should allow nodes with values', () => {

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -3,6 +3,7 @@ let _ = require('lodash/fp')
 let facet = require('../../src/example-types/facet')
 let { ObjectID } = require('mongodb')
 let mingo = require('mingo')
+let mongoProvider = require('../../src/index')
 describe('facet', () => {
   describe('facet.hasValue', () => {
     it('Should allow nodes with values', () => {
@@ -506,6 +507,42 @@ describe('facet', () => {
         )
         let ids = _.map(({ name }) => _.toString(name), result.options)
         expect(_.includes('5e9dbd76e991760021124966', ids)).to.be.true
+      })
+      it('when the first and second search result does not  contain the checked value',async()=>{
+        let config ={
+          getProvider:()=>({runSearch:()=>[ {  label: { name: '5' }, _id: 5 } ],
+          }),
+          getSchema:()=>null
+        }
+
+        node.label.collection = Data
+        node.isMongoId = null
+        node.values = [5]
+        let result = await facet.result(node, agg =>
+          mingo.aggregate(Data, agg),null,config
+        )
+        let ids = _.map(({ name }) => _.toString(name), result.options)
+        expect(_.includes('5', ids)).to.be.true
+      })
+      it('when the first and second search result does not  contain the checked value  and  isMongoId is true',async()=>{
+        let config ={
+          getProvider:()=>({runSearch:()=>[ {  label: { name: 'test' }, _id: '5ce30b403aa154002d01b9dd' } ],
+          }),
+          getSchema:()=>null
+        }
+
+        let collection = _.map(
+          ({ _id, name }) => ({ _id: ObjectID(_id), name }),
+          mongoIdData
+        )
+        node.isMongoId = true
+        node.label.collection = collection
+        node.values = ['5ce30b403aa154002d01b9dd']
+        let result = await facet.result(node, agg =>
+          mingo.aggregate(collection, agg),null,config
+        )
+        let ids = _.map(({ name }) => _.toString(name), result.options)
+        expect(_.includes('5ce30b403aa154002d01b9dd', ids)).to.be.true
       })
     })
   })


### PR DESCRIPTION
fix #82 

the mongo search may not include the checked values. 
1.when no checked values are missing from the First search the search result is the result from first search
2. when there are missed values run the second search.
3. if the value still missing (not able to get the checked value from search) run the third search.
when 2 or 3 happens. the final result is the combination of 1st,2nd, and 3rd search  
 

