### PR TITLE
Allow passing `as` in populate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.17.6
+# 0.18.0
 * support converting the 'as' attribute to the $lookup 'as' prop
 
 # 0.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.17.6
-* Support as pops to lookup Populate Items
+* support converting the 'as' attribute to the $lookup 'as' prop
 
 # 0.17.5
 * Sort early when "hasMany" is set on a "populate" field, but we are not sorting on a joined field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.17.6
+* Support as pops to lookup Populate Items
+
 # 0.17.5
 * Sort early when "hasMany" is set on a "populate" field, but we are not sorting on a joined field
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.17.6",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.17.6",
+  "version": "0.18.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -31,7 +31,7 @@ let convertPopulate = getSchema =>
       let $lookup = [
         {
           $lookup: {
-            as,
+            as: x.as || as,
             from: targetCollection,
             localField: x.localField, // || '_id',
             foreignField: x.foreignField, // || node.schema, <-- needs schema lookup

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -45,6 +45,40 @@ describe('results', () => {
         },
       ])
     })
+    it('support converting the \'as\'  attribute to the $lookup \'as\' prop', () => {
+      let populate = {
+        author: {
+          schema: 'user',
+          localField: 'createdBy',
+          foreignField: '_id',
+          as:'keyAuthor'
+        },
+        org: {
+          schema: 'organization',
+          localField: 'organization',
+          foreignField: '_id',
+          as:'keyOrg'
+        },
+      }
+      expect(convertPopulate(getSchema)(populate)).to.deep.equal([
+        {
+          $lookup: {
+            as: 'keyAuthor',
+            from: 'user',
+            localField: 'createdBy',
+            foreignField: '_id',
+          },
+        },
+        {
+          $lookup: {
+            as: 'keyOrg',
+            from: 'organization',
+            localField: 'organization',
+            foreignField: '_id',
+          },
+        },
+      ])
+    })
     it('should add "$unwind" stage if "unwind" is present in the populate config', () => {
       let populate = {
         author: {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -45,19 +45,19 @@ describe('results', () => {
         },
       ])
     })
-    it('support converting the \'as\'  attribute to the $lookup \'as\' prop', () => {
+    it("support converting the 'as'  attribute to the $lookup 'as' prop", () => {
       let populate = {
         author: {
           schema: 'user',
           localField: 'createdBy',
           foreignField: '_id',
-          as:'keyAuthor'
+          as: 'keyAuthor',
         },
         org: {
           schema: 'organization',
           localField: 'organization',
           foreignField: '_id',
-          as:'keyOrg'
+          as: 'keyOrg',
         },
       }
       expect(convertPopulate(getSchema)(populate)).to.deep.equal([


### PR DESCRIPTION
Starting point for @chris110408. Just needs changelog, package.json, all that jazz

The purpose here is to allow populates that would otherwise have `.` in the key to use arbitrary keys and put their field paths in `as` (called `as` to match the $lookup API, but this could also be called something else)