### PR TITLE
[Results] fix populate include bug (missing $ prefix on localField)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.19.1
+* [Results] fix populate include bug (missing $ prefix on localField)
+
 # 0.19.0
 * [Results] add `include` support on populate config
 * [Results] default `foreignField` to `_id` if not provided

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -21,7 +21,7 @@ let convertPopulate = getSchema =>
           ? {
             as,
             from: targetCollection,
-            let: { localField },
+            let: { localField: `$${localField}` },
             pipeline: [
               { 
                 $match: {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -103,7 +103,7 @@ describe('results', () => {
           $lookup: {
             as: 'author',
             from: 'user',
-            let: { localField: 'createdBy' },
+            let: { localField: '$createdBy' },
             pipeline: [
               { $match : {$expr: {$eq:['$_id', '$$localField']}}},
               {$project: {
@@ -118,7 +118,7 @@ describe('results', () => {
           $lookup: {
             as: 'org',
             from: 'organization',
-            let: { localField: 'organization' },
+            let: { localField: '$organization' },
             pipeline: [
               { $match : {$expr: {$eq:['$_id', '$$localField']}}},
               {$project: {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -106,13 +106,7 @@ describe('results', () => {
             let: { localField: '$createdBy' },
             pipeline: [
               { $match: { $expr: { $eq: ['$_id', '$$localField'] } } },
-              {
-                $project: {
-                  _id: 1,
-                  firstName: 1,
-                  lastName: 1,
-                },
-              },
+              { $project: { _id: 1, firstName: 1, lastName: 1 } },
             ],
           },
         },
@@ -123,12 +117,7 @@ describe('results', () => {
             let: { localField: '$organization' },
             pipeline: [
               { $match: { $expr: { $eq: ['$_id', '$$localField'] } } },
-              {
-                $project: {
-                  _id: 1,
-                  name: 1,
-                },
-              },
+              { $project: { _id: 1, name: 1 } },
             ],
           },
         },


### PR DESCRIPTION
This PR:
- [[Results] fix populate include bug (missing $ prefix on localField)](https://github.com/smartprocure/contexture-mongo/pull/95/commits/4d768252e61e30064648c44e6b7a38fdcd9bd9ec)

Also, I accidentally pushed the changes directly to master before for 0.19.0 which adds include support on populate in the first place 😱 

Prior changes:
- [add support for include on results populate](https://github.com/smartprocure/contexture-mongo/commit/0f87b47a5cbed4764e91002eff1dec53a01fe0c1)
- [default populate foreignField to _id if not provided](https://github.com/smartprocure/contexture-mongo/commit/6500f349096bdf8bc5bcc973613ce5327d800c1a)


Each of the linked commits is self-contained.