### PR TITLE
feature/99 - checkPopulate fn for results node populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.20.0
+* [Results] check populate localField props for coherence with node includes
+
 # 0.19.1
 * [Results] fix populate include bug (missing $ prefix on localField)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,6 +1,14 @@
 let F = require('futil')
 let _ = require('lodash/fp')
 
+let checkPopulate = ({ include: nodeIncludes, populate }) =>
+  _.reduce((incs, { localFieldName, localField, include }) => {
+    if (!_.includes(localField, incs)) {
+      throw Error(`Cannot populate an unincluded field: ${localField}`)
+    }
+    return _.concat(incs, _.map(inc => `${localFieldName}.${inc}`, include))
+  }, nodeIncludes, F.unkeyBy('localFieldName', populate))
+
 let convertPopulate = getSchema =>
   _.flow(
     F.mapIndexed((x, as) => {
@@ -124,6 +132,7 @@ let getResponse = (node, results, count) => {
 
 let result = async (node, search, schema, { getSchema }) => {
   node = defaults(node)
+  checkPopulate(node)
   let hasMany = _.some(_.get('hasMany'), node.populate)
   let resultsQuery = getResultsQuery(node, getSchema, getStartRecord(node))
   let countQuery = [
@@ -147,6 +156,7 @@ module.exports = {
   defaults,
   projectFromInclude,
   convertPopulate,
+  checkPopulate,
   // API
   result,
 }

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -2,12 +2,19 @@ let F = require('futil')
 let _ = require('lodash/fp')
 
 let checkPopulate = ({ include: nodeIncludes, populate }) =>
-  _.reduce((incs, { localFieldName, localField, include }) => {
-    if (!_.includes(localField, incs)) {
-      throw Error(`Cannot populate an unincluded field: ${localField}`)
-    }
-    return _.concat(incs, _.map(inc => `${localFieldName}.${inc}`, include))
-  }, nodeIncludes, F.unkeyBy('localFieldName', populate))
+  _.reduce(
+    (incs, { localFieldName, localField, include }) => {
+      if (!_.includes(localField, incs)) {
+        throw Error(`Cannot populate an unincluded field: ${localField}`)
+      }
+      return _.concat(
+        incs,
+        _.map(inc => `${localFieldName}.${inc}`, include)
+      )
+    },
+    nodeIncludes,
+    F.unkeyBy('localFieldName', populate)
+  )
 
 let convertPopulate = getSchema =>
   _.flow(

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,7 +1,7 @@
 let F = require('futil')
 let _ = require('lodash/fp')
 
-let checkPopulate = ({ include: nodeIncludes, populate }) =>
+let checkPopulate = ({ include: nodeIncludes, populate }, { fields } = {}) =>
   _.reduce(
     (incs, { localFieldName, localField, include }) => {
       if (!_.includes(localField, incs)) {
@@ -12,7 +12,7 @@ let checkPopulate = ({ include: nodeIncludes, populate }) =>
         _.map(inc => `${localFieldName}.${inc}`, include)
       )
     },
-    nodeIncludes,
+    nodeIncludes || _.keys(fields),
     F.unkeyBy('localFieldName', populate)
   )
 
@@ -139,7 +139,7 @@ let getResponse = (node, results, count) => {
 
 let result = async (node, search, schema, { getSchema }) => {
   node = defaults(node)
-  checkPopulate(node)
+  checkPopulate(node, schema)
   let hasMany = _.some(_.get('hasMany'), node.populate)
   let resultsQuery = getResultsQuery(node, getSchema, getStartRecord(node))
   let countQuery = [

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -3,6 +3,7 @@ let { expect } = require('chai')
 let {
   defaults,
   convertPopulate,
+  checkPopulate,
   getResultsQuery,
   getStartRecord,
   getResponse,
@@ -344,6 +345,45 @@ describe('results', () => {
     it('should set totalRecords based on the count (if it exists)', () => {
       expect(getResponse(node, results, 9001).totalRecords).to.equal(9001)
       expect(getResponse(node, results).totalRecords).to.equal(undefined)
+    })
+  })
+  describe('checkPopulate', () => {
+    it('should throw on an unincluded local field', () => {
+      let node = {
+        include: [
+          'createdBy',
+          '_createdByOrganization',
+        ],
+        populate: {
+          createdBy: {
+            localField: 'createdBy',
+            include: ['_id', 'firstName', 'lastName'],
+          },
+          _createdByOrganization: {
+            localField: 'createdBy.organization',
+          },
+        },
+      }
+      expect(() => checkPopulate(node)).to.throw()
+
+    })
+    it('should not throw when includes check out', () => {
+      let node = {
+        include: [
+          'createdBy',
+          '_createdByOrganization',
+        ],
+        populate: {
+          createdBy: {
+            localField: 'createdBy',
+            include: ['_id', 'firstName', 'lastName', 'organization'],
+          },
+          _createdByOrganization: {
+            localField: 'createdBy.organization',
+          },
+        },
+      }
+      expect(() => checkPopulate(node)).not.to.throw()
     })
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -363,7 +363,7 @@ describe('results', () => {
       }
       expect(() => checkPopulate(node)).to.throw()
     })
-    it('should not throw when includes check out', () => {
+    it('should not throw when include checks out', () => {
       let node = {
         include: ['createdBy', '_createdByOrganization'],
         populate: {
@@ -377,6 +377,36 @@ describe('results', () => {
         },
       }
       expect(() => checkPopulate(node)).not.to.throw()
+    })
+    it('should throw for omitted node.include when schema does not the lookup either', () => {
+      let node = {
+        populate: {
+          createdBy: {
+            localField: 'createdBy',
+            include: ['_id', 'firstName', 'lastName', 'organization'],
+          },
+          _createdByOrganization: {
+            localField: 'createdBy.organization',
+          },
+        },
+      }
+      let schema = { fields: { firstName: {}, lastName: {} } }
+      expect(() => checkPopulate(node, schema)).to.throw()
+    })
+    it('should not throw for omitted node.include when schema supports the lookup', () => {
+      let node = {
+        populate: {
+          createdBy: {
+            localField: 'createdBy',
+            include: ['_id', 'firstName', 'lastName', 'organization'],
+          },
+          _createdByOrganization: {
+            localField: 'createdBy.organization',
+          },
+        },
+      }
+      let schema = { fields: { createdBy: {} } }
+      expect(() => checkPopulate(node, schema)).not.to.throw()
     })
   })
 })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -350,10 +350,7 @@ describe('results', () => {
   describe('checkPopulate', () => {
     it('should throw on an unincluded local field', () => {
       let node = {
-        include: [
-          'createdBy',
-          '_createdByOrganization',
-        ],
+        include: ['createdBy', '_createdByOrganization'],
         populate: {
           createdBy: {
             localField: 'createdBy',
@@ -365,14 +362,10 @@ describe('results', () => {
         },
       }
       expect(() => checkPopulate(node)).to.throw()
-
     })
     it('should not throw when includes check out', () => {
       let node = {
-        include: [
-          'createdBy',
-          '_createdByOrganization',
-        ],
+        include: ['createdBy', '_createdByOrganization'],
         populate: {
           createdBy: {
             localField: 'createdBy',

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -378,7 +378,7 @@ describe('results', () => {
       }
       expect(() => checkPopulate(node)).not.to.throw()
     })
-    it('should throw for omitted node.include when schema does not the lookup either', () => {
+    it('should throw for omitted node.include when schema does not support the lookup either', () => {
       let node = {
         populate: {
           createdBy: {
@@ -390,6 +390,8 @@ describe('results', () => {
           },
         },
       }
+      // either node.include or the schema itself should include the field we're
+      // trying to populate. If not the code should be expected to throw an error
       let schema = { fields: { firstName: {}, lastName: {} } }
       expect(() => checkPopulate(node, schema)).to.throw()
     })


### PR DESCRIPTION
It's possible to create a hard-to-debug long-running query by trying to populate a field you didn't include with a previous populate or the base includes. Code here includes a fn to check for this situation and throw an error 