### PR TITLE
Feature/101 - improve results node performance when includes are present on populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.19.2
+* [Results] imporove performance when includes are present on a results node populate
+
 # 0.19.1
 * [Results] fix populate include bug (missing $ prefix on localField)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,6 +1,11 @@
 let F = require('futil')
 let _ = require('lodash/fp')
 
+/*
+ * Takes `({ fields: { firstName: '', lastName: ''} }, ['firstName'], 'nickname')`
+ * and returns `{ nickname.lastName: 0 }`. Used to filter the props of $lookup-ed records
+ * for populates down to the includes specified in those populates
+ */
 let omitFromInclude = (schema, include, as) => {
   let allTargetFields = _.keys(_.get('fields', schema))
   let omittedFields = _.difference(allTargetFields, include)
@@ -35,6 +40,12 @@ let convertPopulate = getSchema =>
         },
       }
 
+      // at this point we know we want to place the foreign collection record on the
+      // local record at the `as` prop, narrowing the foreign record's props down to those
+      // specified by the populate's includes. In order not to lose the other props on the 
+      // local record aside from the `as` prop, we need to omit the fields of the `as` prop
+      // object we don't want by diffing the populate's includes with the foreign schema
+      // specified by the populate. THis is what the `omitFromInclude` util does
       let $project = include
         ? { $project: omitFromInclude(targetSchema, include, as) }
         : null

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -42,7 +42,7 @@ let convertPopulate = getSchema =>
 
       // at this point we know we want to place the foreign collection record on the
       // local record at the `as` prop, narrowing the foreign record's props down to those
-      // specified by the populate's includes. In order not to lose the other props on the 
+      // specified by the populate's includes. In order not to lose the other props on the
       // local record aside from the `as` prop, we need to omit the fields of the `as` prop
       // object we don't want by diffing the populate's includes with the foreign schema
       // specified by the populate. THis is what the `omitFromInclude` util does

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -1,7 +1,7 @@
 let F = require('futil')
 let _ = require('lodash/fp')
 
-let omitFromInclude  = (schema, include, as) => {
+let omitFromInclude = (schema, include, as) => {
   let allTargetFields = _.keys(_.get('fields', schema))
   let omittedFields = _.difference(allTargetFields, include)
 
@@ -26,25 +26,27 @@ let convertPopulate = getSchema =>
           `The ${schema} schema has a mongo configuration without a 'collection' property`
         )
 
-        let $lookup = {
-          $lookup: {
-            as,
-            from: targetCollection,
-            localField,
-            foreignField, // || node.schema, <-- needs schema lookup
-          }
-        }
+      let $lookup = {
+        $lookup: {
+          as,
+          from: targetCollection,
+          localField,
+          foreignField, // || node.schema, <-- needs schema lookup
+        },
+      }
 
-        let $project = include ? { $project: omitFromInclude(targetSchema, include, as) } : null
+      let $project = include
+        ? { $project: omitFromInclude(targetSchema, include, as) }
+        : null
 
-        let $unwind = unwind && {
-          $unwind: {
-            path: `$${as}`,
-            preserveNullAndEmptyArrays: true,
-          },
-        }
+      let $unwind = unwind && {
+        $unwind: {
+          path: `$${as}`,
+          preserveNullAndEmptyArrays: true,
+        },
+      }
 
-        return _.compact([$lookup, $unwind, $project])
+      return _.compact([$lookup, $unwind, $project])
     }),
     _.flatten
   )

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -2,7 +2,7 @@ let F = require('futil')
 let _ = require('lodash/fp')
 
 let omitFromInclude  = (schema, include, as) => {
-  let allTargetFields = _.keys(F.flattenObject(_.get('mongo.fields', schema)))
+  let allTargetFields = _.keys(F.flattenObject(_.get('fields', schema)))
   let omittedFields = _.difference(allTargetFields, include)
 
   return F.arrayToObject(

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -2,7 +2,7 @@ let F = require('futil')
 let _ = require('lodash/fp')
 
 let omitFromInclude  = (schema, include, as) => {
-  let allTargetFields = _.keys(F.flattenObject(_.get('fields', schema)))
+  let allTargetFields = _.keys(_.get('fields', schema))
   let omittedFields = _.difference(allTargetFields, include)
 
   return F.arrayToObject(

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -2,8 +2,8 @@ let F = require('futil')
 let _ = require('lodash/fp')
 
 /*
- * Takes `({ fields: { firstName: '', lastName: ''} }, ['firstName'], 'nickname')`
- * and returns `{ nickname.lastName: 0 }`. Used to filter the props of $lookup-ed records
+ * Takes `({ fields: { firstName: '', lastName: '' } }, ['firstName'], 'createdBy')`
+ * and returns `{ createdBy.lastName: 0 }`. Used to filter the props of $lookup-ed records
  * for populates down to the includes specified in those populates
  */
 let omitFromInclude = (schema, include, as) => {

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -93,27 +93,29 @@ describe('results', () => {
           include: ['_id', 'firstName', 'lastName'],
         },
       }
-      let getTestSchema = () => ({ mongo: { collection: 'user' },
-      fields: {
-        _id: {},
-        firstName: 'John',
-        lastName: 'Smith',
-        password: 'doNotLetMeThrough'
-      } })
+      let getTestSchema = () => ({
+        mongo: { collection: 'user' },
+        fields: {
+          _id: {},
+          firstName: 'John',
+          lastName: 'Smith',
+          password: 'doNotLetMeThrough',
+        },
+      })
       expect(convertPopulate(getTestSchema)(populate)).to.deep.equal([
         {
-          "$lookup": {
-            "as": "author",
-            "from": "user",
-            "localField": "createdBy",
-            "foreignField": "_id"
-          }
+          $lookup: {
+            as: 'author',
+            from: 'user',
+            localField: 'createdBy',
+            foreignField: '_id',
+          },
         },
         {
-          "$project": {
-            "author.password": 0
-          }
-        }
+          $project: {
+            'author.password': 0,
+          },
+        },
       ])
     })
   })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -92,35 +92,28 @@ describe('results', () => {
           foreignField: '_id',
           include: ['_id', 'firstName', 'lastName'],
         },
-        org: {
-          schema: 'organization',
-          localField: 'organization',
-          include: ['_id', 'name'],
-        },
       }
-      expect(convertPopulate(getSchema)(populate)).to.deep.equal([
+      let getTestSchema = () => ({ mongo: { collection: 'user',
+      fields: {
+        _id: {},
+        firstName: 'John',
+        lastName: 'Smith',
+        password: 'doNotLetMeThrough'
+      } }})
+      expect(convertPopulate(getTestSchema)(populate)).to.deep.equal([
         {
-          $lookup: {
-            as: 'author',
-            from: 'user',
-            let: { localField: '$createdBy' },
-            pipeline: [
-              { $match: { $expr: { $eq: ['$_id', '$$localField'] } } },
-              { $project: { _id: 1, firstName: 1, lastName: 1 } },
-            ],
-          },
+          "$lookup": {
+            "as": "author",
+            "from": "user",
+            "localField": "createdBy",
+            "foreignField": "_id"
+          }
         },
         {
-          $lookup: {
-            as: 'org',
-            from: 'organization',
-            let: { localField: '$organization' },
-            pipeline: [
-              { $match: { $expr: { $eq: ['$_id', '$$localField'] } } },
-              { $project: { _id: 1, name: 1 } },
-            ],
-          },
-        },
+          "$project": {
+            "author.password": 0
+          }
+        }
       ])
     })
   })

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -84,7 +84,7 @@ describe('results', () => {
         },
       ])
     })
-    it('should use a pipeline and project for $lookup objects with include', () => {
+    it('should do populate includes by omitting from the base record', () => {
       let populate = {
         author: {
           schema: 'user',
@@ -93,13 +93,13 @@ describe('results', () => {
           include: ['_id', 'firstName', 'lastName'],
         },
       }
-      let getTestSchema = () => ({ mongo: { collection: 'user',
+      let getTestSchema = () => ({ mongo: { collection: 'user' },
       fields: {
         _id: {},
         firstName: 'John',
         lastName: 'Smith',
         password: 'doNotLetMeThrough'
-      } }})
+      } })
       expect(convertPopulate(getTestSchema)(populate)).to.deep.equal([
         {
           "$lookup": {


### PR DESCRIPTION
Fixes #101 

### Discussion
* the two forms of the mongo $lookup are supposed to be equivalent, but they clearly don't use indexes the same way because as noted on the issue changing the form can massively impact performance
* change here always uses the fast form of the $lookup when doing includes for a results node populate
* works under the hood by omitting from the populated base record rather than projecting during the lookup pipeline. Luckily the presence of the schema makes this optimization possible