### PR TITLE
Allow passing as in populate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.20.0
+# 0.21.0
 * support converting the 'as' attribute to the $lookup 'as' prop
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.0
+* support converting the 'as' attribute to the $lookup 'as' prop
+
+
 # 0.19.2
 * [Results] imporove performance when includes are present on a results node populate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -33,7 +33,7 @@ let convertPopulate = getSchema =>
 
       let $lookup = {
         $lookup: {
-          as,
+          as: x.as || as,
           from: targetCollection,
           localField,
           foreignField, // || node.schema, <-- needs schema lookup

--- a/test/example-types/results.js
+++ b/test/example-types/results.js
@@ -45,6 +45,42 @@ describe('results', () => {
         },
       ])
     })
+
+    it("support converting the 'as'  attribute to the $lookup 'as' prop", () => {
+      let populate = {
+        author: {
+          schema: 'user',
+          localField: 'createdBy',
+          foreignField: '_id',
+          as: 'keyAuthor',
+        },
+        org: {
+          schema: 'organization',
+          localField: 'organization',
+          foreignField: '_id',
+          as: 'keyOrg',
+        },
+      }
+      expect(convertPopulate(getSchema)(populate)).to.deep.equal([
+        {
+          $lookup: {
+            as: 'keyAuthor',
+            from: 'user',
+            localField: 'createdBy',
+            foreignField: '_id',
+          },
+        },
+        {
+          $lookup: {
+            as: 'keyOrg',
+            from: 'organization',
+            localField: 'organization',
+            foreignField: '_id',
+          },
+        },
+      ])
+    })
+
     it('should add "$unwind" stage if "unwind" is present in the populate config', () => {
       let populate = {
         author: {


### PR DESCRIPTION
The purpose here is to allow populates that would otherwise have . in the key to use arbitrary keys and put their field paths in as (called as to match the $lookup API, but this could also be called something else)