### PR TITLE
Should not filter 0 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #0.22.2
-* fix the bug the response of facet remove the 0 value name option ( compactObject consider it  as a falsey value ).
+* fix the bug the response of facet remove the 0 value name option ( compactObject consider it  as a false value ).
 
 #0.22.1
 * [Results] further improved `as`-aware `checkPopulate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.22.2
+* fix the bug the response of facet remove the 0 value name option ( compactObject consider it  as a falsey value ).
+
 #0.22.1
 * [Results] further improved `as`-aware `checkPopulate`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -51,7 +51,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
@@ -524,7 +524,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3977,9 +3977,9 @@
       "dev": true
     },
     "mingo": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-2.5.2.tgz",
-      "integrity": "sha512-Qe5NyDKqT+kbLrPKTody1tsD8osOgE8vge0czECKR1LMeWrIE6Cd7O/5Y4djeVZrv4C2wcbxM0t0Hfjkh+Dp8g==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-4.1.2.tgz",
+      "integrity": "sha512-WQKhtFDV7nRIMlPP7tfo0Zx4bpvmhfBuHKvNPA9DbISjYJtrU4g1kacQPxPhMSEebJ6tGz7pHXDzQOyANpJ9jA==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "duti": "latest",
     "eslint": "^4.12.1",
     "eslint-config-smartprocure": "^1.1.0",
-    "mingo": "^2.5.2",
+    "mingo": "^4.1.2",
     "mocha": "^3.5.3",
     "mongodb": "^3.5.6",
     "mongodb-memory-server": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -143,7 +143,7 @@ module.exports = {
       cardinality: _.get('0.count', cardinality),
       options: _.map(
         ({ _id, label, count }) =>
-          F.compactObject({
+          F.omitNil({
             name: _id,
             count,
             ...facetValueLabel(node, label),

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -141,7 +141,7 @@ module.exports = {
       ]),
     ]).then(([options, cardinality]) => ({
       cardinality: _.get('0.count', cardinality),
-      options: _.map(
+      options: console.log(options)||_.map(
         ({ _id, label, count }) =>
           F.omitNil({
             name: _id,

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -141,7 +141,7 @@ module.exports = {
       ]),
     ]).then(([options, cardinality]) => ({
       cardinality: _.get('0.count', cardinality),
-      options: console.log(options)||_.map(
+      options: _.map(
         ({ _id, label, count }) =>
           F.omitNil({
             name: _id,

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -2,6 +2,9 @@ let { expect } = require('chai')
 let _ = require('lodash/fp')
 let facet = require('../../src/example-types/facet')
 let { ObjectId } = require('mongodb')
+require('mingo/init/system')
+
+
 let mingo = require('mingo')
 describe('facet', () => {
   describe('facet.hasValue', () => {
@@ -252,6 +255,29 @@ describe('facet', () => {
           { name: 1, count: 3 },
           { name: 2, count: 2 },
           { name: 3, count: 1 },
+        ],
+      })
+    })
+
+    it('should not filter the 0 value', async () => {
+      let activities = [
+        { _id: 1,  number: 0 },
+        { _id: 1, number: 1 }
+
+      ]
+      let node = {
+        field: 'number',
+      }
+
+      let result = await facet.result(node, agg =>
+        mingo.aggregate(activities, agg)
+      )
+
+      expect(result).to.deep.equal({
+        cardinality: 2,
+        options: [
+          { name: 0, count: 1 },
+          { name: 1, count: 1 },
         ],
       })
     })

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -255,6 +255,29 @@ describe('facet', () => {
         ],
       })
     })
+    it.only('should not filter the 0 value', async () => {
+      let activities = [
+        { _id: 1,  number: 0 },
+        { _id: 1, number: 1 }
+
+      ]
+      let node = {
+        field: 'number',
+      }
+
+      let result = await facet.result(node, agg =>
+        mingo.aggregate(activities, agg)
+      )
+
+      expect(result).to.deep.equal({
+        cardinality: 2,
+        options: [
+          { name: 0, count: 1 },
+          { name: 1, count: 1 },
+        ],
+      })
+    })
+
     it('should support optionsFilter with a lookup that returns a single field', async () => {
       queries = []
 

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -255,28 +255,6 @@ describe('facet', () => {
         ],
       })
     })
-    it.only('should not filter the 0 value', async () => {
-      let activities = [
-        { _id: 1,  number: 0 },
-        { _id: 1, number: 1 }
-
-      ]
-      let node = {
-        field: 'number',
-      }
-
-      let result = await facet.result(node, agg =>
-        mingo.aggregate(activities, agg)
-      )
-
-      expect(result).to.deep.equal({
-        cardinality: 2,
-        options: [
-          { name: 0, count: 1 },
-          { name: 1, count: 1 },
-        ],
-      })
-    })
 
     it('should support optionsFilter with a lookup that returns a single field', async () => {
       queries = []

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -4,7 +4,6 @@ let facet = require('../../src/example-types/facet')
 let { ObjectId } = require('mongodb')
 require('mingo/init/system')
 
-
 let mingo = require('mingo')
 describe('facet', () => {
   describe('facet.hasValue', () => {
@@ -261,9 +260,8 @@ describe('facet', () => {
 
     it('should not filter the 0 value', async () => {
       let activities = [
-        { _id: 1,  number: 0 },
-        { _id: 1, number: 1 }
-
+        { _id: 1, number: 0 },
+        { _id: 1, number: 1 },
       ]
       let node = {
         field: 'number',


### PR DESCRIPTION
fixes #108

 fix the bug the response of facet remove the 0 value name option ( `compactObject` consider it as a false value ).
switch the `compactObject`  to omitNil