### PR TITLE
fix bug when populate is restricting what fields to return/project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.22.3
+* fix bug when populate is restricting what fields (specifically when the `include` has nested object fields) to return from the looked up record based on the `include` provided  
+
 #0.22.2
 * fix the bug the response of facet remove the 0 value name option ( compactObject consider it  as a false value ).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -28,7 +28,14 @@ let checkPopulate = ({ include: nodeIncludes, populate }) =>
  */
 let omitFromInclude = (schema, include, as) => {
   let allTargetFields = _.keys(_.get('fields', schema))
-  let omittedFields = _.difference(allTargetFields, include)
+  let omittedFields = _.reject(
+    field =>
+      _.some(
+        includeField => _.startsWith(`${includeField}.`, `${field}.`),
+        include
+      ),
+    allTargetFields
+  )
 
   return F.arrayToObject(
     field => `${as}.${field}`,


### PR DESCRIPTION
fix bug when populate is restricting what fields to return from the looked up record based on the `include` provided

reference https://github.com/smartprocure/spark/issues/5852