### PR TITLE
Fix omitFromInclude bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.22.4
+* fix bug when populate is restricting what fields (specifically when the `include` has dotted object fields when the schema only has the parent object) to return from the looked up record based on the `include` provided
+
 #0.22.3
 * fix bug when populate is restricting what fields (specifically when the `include` has nested object fields) to return from the looked up record based on the `include` provided  
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/results.js
+++ b/src/example-types/results.js
@@ -31,7 +31,13 @@ let omitFromInclude = (schema, include, as) => {
   let omittedFields = _.reject(
     field =>
       _.some(
-        includeField => _.startsWith(`${includeField}.`, `${field}.`),
+        // do NOT omit if:
+        // - include field is an exact match of schema field
+        // - schema field is part of an object field specified by the include field (schemaField = 'topLevel.nestedField' and includeField = 'topLevel')
+        // - include field is a dotted field that is part of a schema object field (schemaField = 'topLevel' and includeField = 'topLevel.nestedField')
+        includeField =>
+          _.startsWith(`${includeField}.`, `${field}.`) ||
+          _.startsWith(`${field}.`, `${includeField}.`),
         include
       ),
     allTargetFields


### PR DESCRIPTION
When populate is restricting what fields (specifically when the `include` has dotted object fields when the schema only has the parent object) to return from the looked up record based on the `include` provided

reference https://github.com/smartprocure/spark/issues/5852