### PR TITLE
Optimize facet optionsFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.24.0
+* Change facet type optionsFilter to $and all words by doing a $regex match for each word as opposed to all words at once 
+
 #0.23.0
 * Add last 1 Day and last 1 hour to date math calculations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/src/example-types/facet.js
+++ b/src/example-types/facet.js
@@ -32,7 +32,7 @@ let getMatchesForMultipleKeywords = (list, optionsFilter) => ({
       $or: _.map(
         key => ({
           [key]: {
-            $regex: F.wordsToRegexp(option),
+            $regex: option,
             $options: 'i',
           },
         }),
@@ -47,10 +47,15 @@ let setMatchOperators = (list, node) =>
   list.length > 1
     ? getMatchesForMultipleKeywords(list, node.optionsFilter)
     : {
-        [_.first(list)]: {
-          $regex: F.wordsToRegexp(node.optionsFilter),
-          $options: 'i',
-        },
+        $and: _.flow(
+          _.words,
+          _.map(option => ({
+            [_.first(list)]: {
+              $options: 'i',
+              $regex: option,
+            },
+          }))
+        )(node.optionsFilter),
       }
 
 let mapKeywordFilters = node =>

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -66,10 +66,14 @@ describe('facet', () => {
       let filterAgg = _.find('$match', queries[0])
       expect(filterAgg).to.deep.equal({
         $match: {
-          _id: {
-            $regex: '.*(?=.*cable.*).*',
-            $options: 'i',
-          },
+          $and: [
+            {
+              _id: {
+                $options: 'i',
+                $regex: 'cable',
+              },
+            },
+          ],
         },
       })
       // Also make sure that options filtering happens _before_ limiting
@@ -87,10 +91,20 @@ describe('facet', () => {
       let filterAgg = _.find('$match', queries[0])
       expect(filterAgg).to.deep.equal({
         $match: {
-          _id: {
-            $regex: '.*(?=.*dis.*)(?=.*comp.*).*',
-            $options: 'i',
-          },
+          $and: [
+            {
+              _id: {
+                $options: 'i',
+                $regex: 'dis',
+              },
+            },
+            {
+              _id: {
+                $options: 'i',
+                $regex: 'comp',
+              },
+            },
+          ],
         },
       })
       // Also make sure that options filtering happens _before_ limiting
@@ -311,10 +325,14 @@ describe('facet', () => {
       let filterAgg = _.find('$match', queries[0])
       expect(filterAgg).to.deep.equal({
         $match: {
-          'label.firstName': {
-            $regex: '.*(?=.*jane.*).*',
-            $options: 'i',
-          },
+          $and: [
+            {
+              'label.firstName': {
+                $options: 'i',
+                $regex: 'jane',
+              },
+            },
+          ],
         },
       })
 
@@ -369,13 +387,13 @@ describe('facet', () => {
               $or: [
                 {
                   'label.firstName': {
-                    $regex: '.*(?=.*fred.*).*',
+                    $regex: 'fred',
                     $options: 'i',
                   },
                 },
                 {
                   'label.lastName': {
-                    $regex: '.*(?=.*fred.*).*',
+                    $regex: 'fred',
                     $options: 'i',
                   },
                 },
@@ -385,13 +403,13 @@ describe('facet', () => {
               $or: [
                 {
                   'label.firstName': {
-                    $regex: '.*(?=.*smith.*).*',
+                    $regex: 'smith',
                     $options: 'i',
                   },
                 },
                 {
                   'label.lastName': {
-                    $regex: '.*(?=.*smith.*).*',
+                    $regex: 'smith',
                     $options: 'i',
                   },
                 },


### PR DESCRIPTION
* Change facet type optionsFilter to $and all words by doing a $regex match for each word as opposed to all words at once

reference https://github.com/smartprocure/spark/issues/10484