### PR TITLE
Fix for facet cardinality when it is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.26.0
+* Make sure `facet` type uses options filter(s) (if any) for cardinality query
+
 # 0.25.2
 * Updated peerDependency to reflect current requirement
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "contexture-mongo",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.25.2",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^2.3.0",
@@ -79,7 +79,7 @@
     },
     "node_modules/@elastic/datemath/node_modules/lodash": {
       "version": "3.10.1",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
     "node_modules/@octokit/auth-token": {
@@ -648,7 +648,7 @@
     },
     "node_modules/babel-code-frame/node_modules/chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "dependencies": {
@@ -7476,7 +7476,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
@@ -7978,7 +7978,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-mongo",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Mongo Provider for Contexture",
   "main": "src/index.js",
   "scripts": {

--- a/test/example-types/facet.js
+++ b/test/example-types/facet.js
@@ -341,7 +341,7 @@ describe('facet', () => {
       )
 
       expect(result).to.deep.equal({
-        cardinality: 3,
+        cardinality: 1,
         options: [
           {
             name: 2,
@@ -424,7 +424,7 @@ describe('facet', () => {
       )
 
       expect(result).to.deep.equal({
-        cardinality: 3,
+        cardinality: 1,
         options: [
           {
             name: 1,


### PR DESCRIPTION
* Make sure `facet` type uses options filter(s) (if any) for cardinality query

reference https://github.com/smartprocure/spark/issues/11127

`With options filter`

![Screen Shot 2021-07-27 at 3 43 03 PM](https://user-images.githubusercontent.com/532680/127217800-2c012241-6fd9-4e7a-99ae-38b8a72b3f06.png)

`Without options filter`

![Screen Shot 2021-07-27 at 3 44 23 PM](https://user-images.githubusercontent.com/532680/127217808-171f1b74-65d3-492a-8c22-53dc287ad601.png)
