### PR TITLE
fix npm script name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ Aggregates values for a field and groups into time periods specified by `interva
 ## Integration Tests
 
 This repository offers integration tests to practice and understand the example
-types we offer. You can run the integration tests with the command: `npm run test-integration`.
+types we offer. You can run the integration tests with the command: `npm run test:integration`.
 If you have a mongo database available at localhost (default port), the tests
 will connect to it and do changes on a database named `contexture-test`.


### PR DESCRIPTION
This commit fixes an incorrect script name in the command given to run integration tests.